### PR TITLE
story-3-1-auto-price-adjustment-rule-setup - fixes #15

### DIFF
--- a/_bmad-output/implementation-artifacts/3-1-자동-가격조정-규칙-설정.md
+++ b/_bmad-output/implementation-artifacts/3-1-자동-가격조정-규칙-설정.md
@@ -1,32 +1,32 @@
 # Story 3.1: 자동 가격조정 규칙 설정
 
-Status: review
+Status: done
 
 ## Story
 
-As a 판매 사용자,  
-I want 기간/인하율/최저가 하한 기반 가격조정 규칙을 설정하고 싶다,  
+As a 판매 사용자,
+I want 기간/인하율/최저가 하한 기반 가격조정 규칙을 설정하고 싶다,
 so that 가격 관리를 자동화할 수 있다.
 
-**Scope Tag:** Active MVP  
-**Story Type:** Feature / brownfield pricing-rule setup  
+**Scope Tag:** Active MVP
+**Story Type:** Feature / brownfield pricing-rule setup
 **FR Trace:** FR18
 
 ## Acceptance Criteria
 
-1. **Given** 사용자가 가격조정 설정 화면에 진입했을 때  
-   **When** 주기(일), 인하율, 최저가 하한을 입력하고 저장하면  
-   **Then** 규칙이 유효성 검증 후 저장된다  
+1. **Given** 사용자가 가격조정 설정 화면에 진입했을 때
+   **When** 주기(일), 인하율, 최저가 하한을 입력하고 저장하면
+   **Then** 규칙이 유효성 검증 후 저장된다
    **And** 저장된 규칙은 이후 자동 가격조정 대상에서 현재 활성 규칙으로 사용된다.
 
-2. **Given** 주기, 인하율, 최저가 하한 또는 그 조합이 유효하지 않을 때  
-   **When** 사용자가 저장을 요청하면  
-   **Then** 필드별 오류와 복구 가이드가 표시된다  
+2. **Given** 주기, 인하율, 최저가 하한 또는 그 조합이 유효하지 않을 때
+   **When** 사용자가 저장을 요청하면
+   **Then** 필드별 오류와 복구 가이드가 표시된다
    **And** 마지막으로 저장된 유효 규칙은 그대로 유지된다.
 
-3. **Given** 저장된 규칙을 다시 열었을 때  
-   **When** 화면이 로드되면  
-   **Then** 현재 활성 값이 미리 채워져 보여야 한다  
+3. **Given** 저장된 규칙을 다시 열었을 때
+   **When** 화면이 로드되면
+   **Then** 현재 활성 값이 미리 채워져 보여야 한다
    **And** 화면은 모바일/키보드 접근성 기준을 만족해야 한다.
 
 ## Tasks / Subtasks
@@ -51,6 +51,10 @@ so that 가격 관리를 자동화할 수 있다.
   - [x] 규칙 validator 단위 테스트에서 기간/인하율/하한 경계값과 이전 유효 상태 보존을 검증한다.
   - [x] 접근성 검증은 `role`, `label`, focus order, `aria-live` 기준으로 확인한다.
   - [x] 이 스토리에서는 scheduler, history view, event emission, `pricing.auto_adjust.applied.v1` 계약을 구현하지 않는다.
+
+### Review Findings
+
+- [x] [Review][Patch] Story 3.1 diff check whitespace failures fixed [`_bmad-output/implementation-artifacts/3-1-자동-가격조정-규칙-설정.md`:7]
 
 ## Dev Notes
 

--- a/_bmad-output/implementation-artifacts/3-1-자동-가격조정-규칙-설정.md
+++ b/_bmad-output/implementation-artifacts/3-1-자동-가격조정-규칙-설정.md
@@ -55,6 +55,7 @@ so that 가격 관리를 자동화할 수 있다.
 ### Review Findings
 
 - [x] [Review][Patch] Story 3.1 diff check whitespace failures fixed [`_bmad-output/implementation-artifacts/3-1-자동-가격조정-규칙-설정.md`:7]
+- [x] [Review][Patch] Fresh-checkout `typecheck` depends on untracked Next generated route types [`next-env.d.ts`:3]
 
 ## Dev Notes
 

--- a/_bmad-output/implementation-artifacts/3-1-자동-가격조정-규칙-설정.md
+++ b/_bmad-output/implementation-artifacts/3-1-자동-가격조정-규칙-설정.md
@@ -1,0 +1,199 @@
+# Story 3.1: 자동 가격조정 규칙 설정
+
+Status: ready-for-dev
+
+## Story
+
+As a 판매 사용자,  
+I want 기간/인하율/최저가 하한 기반 가격조정 규칙을 설정하고 싶다,  
+so that 가격 관리를 자동화할 수 있다.
+
+**Scope Tag:** Active MVP  
+**Story Type:** Feature / brownfield pricing-rule setup  
+**FR Trace:** FR18
+
+## Acceptance Criteria
+
+1. **Given** 사용자가 가격조정 설정 화면에 진입했을 때  
+   **When** 주기(일), 인하율, 최저가 하한을 입력하고 저장하면  
+   **Then** 규칙이 유효성 검증 후 저장된다  
+   **And** 저장된 규칙은 이후 자동 가격조정 대상에서 현재 활성 규칙으로 사용된다.
+
+2. **Given** 주기, 인하율, 최저가 하한 또는 그 조합이 유효하지 않을 때  
+   **When** 사용자가 저장을 요청하면  
+   **Then** 필드별 오류와 복구 가이드가 표시된다  
+   **And** 마지막으로 저장된 유효 규칙은 그대로 유지된다.
+
+3. **Given** 저장된 규칙을 다시 열었을 때  
+   **When** 화면이 로드되면  
+   **Then** 현재 활성 값이 미리 채워져 보여야 한다  
+   **And** 화면은 모바일/키보드 접근성 기준을 만족해야 한다.
+
+## Tasks / Subtasks
+
+- [ ] 규칙 도메인 계약과 검증 헬퍼를 추가한다. (AC: 1, 2)
+  - [ ] `src/domain/pricing/auto-adjust-rule.ts`를 생성하고 규칙 입력 스키마, 표시 모델, 검증 헬퍼를 정의한다.
+  - [ ] 기간은 정수 일수, 인하율은 정수 퍼센트, 최저가 하한은 KRW 정수로 다루고, 금액 경계는 `listingPricePolicy`를 재사용한다.
+  - [ ] 잘못된 값과 unsafe 조합에 대한 단위 테스트를 `src/domain/pricing/auto-adjust-rule.test.ts`에 추가한다.
+
+- [ ] 규칙 저장 경계와 서버 액션을 구현한다. (AC: 1, 2, 3)
+  - [ ] `src/feature/listing/actions/save-auto-adjust-rule.action.ts`를 생성해 `use server` 경계에서 입력 검증, 저장, 재시도 가능한 form state 반환을 처리한다.
+  - [ ] `src/infra/pricing/auto-adjust-rule.repository.ts` 또는 동등한 infra 저장소를 추가해 page/component에서 직접 persistence를 호출하지 않도록 한다.
+  - [ ] 저장 실패나 검증 실패 시 마지막 유효 규칙을 유지하고, 사용자에게는 복구 가능한 오류만 노출한다.
+
+- [ ] AutoAdjustRulePage와 규칙 선택 UI를 추가한다. (AC: 1, 3)
+  - [ ] `src/app/listings/[listingId]/auto-adjust-rule/page.tsx`를 생성해 규칙 설정 화면을 분리한다.
+  - [ ] `src/feature/listing/components/auto-adjust-rule-selector.client.tsx`를 생성해 모바일 우선 단일 컬럼 폼과 MUI 기반 입력/오류 상태를 제공한다.
+  - [ ] listing detail 화면에서 해당 페이지로 이동할 수 있는 진입점을 제공하되, 상태 변경 UI와 규칙 설정 UI는 섞지 않는다.
+
+- [ ] 테스트를 추가해 Story 3.1의 회귀를 고정한다. (AC: 1, 2, 3)
+  - [ ] `tests/e2e/auto-adjust-rule-flow.spec.ts`를 추가해 유효 규칙 저장, invalid input recovery, reopen/prefill 흐름을 검증한다.
+  - [ ] 규칙 validator 단위 테스트에서 기간/인하율/하한 경계값과 이전 유효 상태 보존을 검증한다.
+  - [ ] 접근성 검증은 `role`, `label`, focus order, `aria-live` 기준으로 확인한다.
+  - [ ] 이 스토리에서는 scheduler, history view, event emission, `pricing.auto_adjust.applied.v1` 계약을 구현하지 않는다.
+
+## Dev Notes
+
+### Story Intent
+
+- Story 3.1은 Epic 3의 시작점이다. 이 스토리는 자동 가격조정의 "실행"이 아니라 "규칙 저장"만 책임진다.
+- Story 3.2가 규칙 실행과 `pricing.auto_adjust.applied.v1` 발생을 소유하고, Story 3.3가 이력/최소 신호를 소유한다.
+- 규칙 설정은 listing status 편집과 분리하고, 가격 추천 흐름과도 분리한다.
+
+### Scope Boundaries
+
+- 포함:
+  - 단일 listing 기준의 현재 활성 자동 가격조정 규칙 저장
+  - 주기/인하율/최저가 하한 검증
+  - 저장 후 재진입 시 값 재표시
+  - 모바일/키보드 접근성 기준 충족
+- 제외:
+  - 스케줄러/cron/queue
+  - 자동 가격조정 실제 실행
+  - 가격 변경 이력 화면
+  - 이벤트 발행 및 관측 파이프라인
+  - Ops console, KPI, feature flag 운영 화면
+
+### Current Workspace Reality
+
+- `src/domain/pricing/pricing-suggestion.ts`와 `src/shared/contracts/events/pricing-suggestion-accepted.v1.ts`는 이미 존재하므로, Story 3.1은 새로운 pricing 하위 모듈을 이 코드와 같은 규칙으로 붙여야 한다.
+- 현재 listing detail 페이지는 [src/app/listings/[listingId]/page.tsx](/C:/Users/ok.works/Projects/PreProduct/src/app/listings/[listingId]/page.tsx)에서 `ListingStatusForm`을 렌더링한다. 규칙 설정은 이 상태 라디오 그룹에 섞지 말고 별도 page/selector로 분리하는 편이 안전하다.
+- [src/feature/listing/components/listing-form.client.tsx](/C:/Users/ok.works/Projects/PreProduct/src/feature/listing/components/listing-form.client.tsx)와 [src/feature/listing/components/listing-submit-bar.client.tsx](/C:/Users/ok.works/Projects/PreProduct/src/feature/listing/components/listing-submit-bar.client.tsx)는 현재 App Router + MUI + `useActionState` 패턴의 기준점이다.
+- `_bmad-output/implementation-artifacts/dependency-graph.md`는 Story 3.1을 next ready backlog로 표시하고, Story 3.2가 Story 3.1에 의존함을 명시한다.
+- `_bmad-output/test-artifacts/test-design-epic-3.md`는 rule validation을 Epic 3의 최상위 리스크로 다루고, invalid config recovery와 last-valid-state preservation을 핵심 검증 포인트로 둔다.
+- repo-root `_bmad-output/project-context.md`는 존재하지 않는다. 이 스토리의 기준선은 `architecture.md`, `epics.md`, `prd.md`, `ux-design-specification.md`, 그리고 현재 코드베이스다.
+
+### Recommended Implementation Shape
+
+- `src/domain/pricing/auto-adjust-rule.ts`
+- `src/domain/pricing/auto-adjust-rule.test.ts`
+- `src/infra/pricing/auto-adjust-rule.repository.ts`
+- `src/feature/listing/actions/save-auto-adjust-rule.action.ts`
+- `src/feature/listing/components/auto-adjust-rule-selector.client.tsx`
+- `src/app/listings/[listingId]/auto-adjust-rule/page.tsx`
+- `src/app/listings/[listingId]/page.tsx` only for the entry CTA and rule summary link
+
+### Data Modeling Guidance
+
+- Persist one active rule per listing unless the team has explicitly introduced versioned rule history. Story 3.2 assumes one current rule to evaluate.
+- Keep the rule payload serializable and compact: `listingId`, `periodDays`, `discountRatePercent`, `floorPriceKrw`, `enabled`, `updatedAt`, and a revision field only if needed for safe updates.
+- Treat the rule schema as a domain contract, not a page-local form shape.
+- Reuse `listingPricePolicy` for monetary bounds. Do not duplicate price policy constants in the page or component layer.
+
+### UX and Accessibility Guardrails
+
+- The rule screen should feel like a focused settings form, not an operations dashboard.
+- Use explicit labels, helper text, and visible active-state summary so the user can verify the current rule before saving.
+- Invalid submission must explain what to change without clearing the last valid values.
+- Keep touch targets at least 44x44 on mobile and preserve keyboard focus order on desktop.
+- Use `aria-live` or an equivalent polite status region for recoverable save errors and success feedback.
+
+### Architecture Compliance
+
+- Follow `feature -> domain -> infra` only. Page/component code must not import infra directly.
+- Keep server-side mutation logic in `*.action.ts` and validate input with Zod before persistence.
+- Use the existing Next.js App Router and MUI patterns already established in the listing flow.
+- Story 3.1 does not emit `pricing.auto_adjust.applied.v1`; that producer responsibility belongs to Story 3.2.
+- Do not add scheduler, history, or Ops routes in this story.
+
+### Previous Story Intelligence
+
+- Story 2.3 established the pattern for controlled state, `useActionState`, and preserving user-entered values across recoverable validation errors.
+- The current listing flow already shows the expected error/reporting style through `Alert`, `FormHelperText`, and the sticky submit bar.
+- Keep the rule form similarly recoverable: failed submit should stay on the same screen with the prior valid state intact.
+
+### Git Intelligence Summary
+
+- Epic 2 is already complete and merged, so Story 3.1 is the first real Epic 3 implementation step.
+- Shared hot files are already busy in `src/domain/pricing/*`, `src/shared/contracts/*`, and `src/app/listings/[listingId]/page.tsx`; keep changes tightly scoped.
+- The dependency graph and Epic 3 test design agree on the main risk: unsafe or invalid rule config.
+
+### Testing Requirements
+
+- Unit test valid rule creation, invalid period, invalid discount, invalid floor, and invalid combination cases.
+- Unit test that the last valid rule survives failed submissions and that revisiting the screen preloads the current values.
+- E2E should cover save, revisit, invalid recovery, and keyboard-safe navigation.
+- Do not add contract or scheduler tests in this story; those belong to later epic stories.
+
+### Specific Risks To Avoid
+
+- Building the scheduler or automatic price mutation too early.
+- Clearing the last valid rule when validation fails.
+- Creating a parallel pricing stack that bypasses `src/domain/pricing`.
+- Adding a global ops-only configuration path for a listing-scoped feature.
+- Calling Prisma directly from the page or component layer.
+- Reusing the listing status form as a mixed-purpose control panel.
+
+### Latest Technical Notes
+
+- Repo-pinned stack: Next.js `16.2.4`, React `19.2.5`, MUI `9.0.0`, Prisma `7.7.0`, Zod `4.3.6`, pnpm `10.28.2`.
+- Existing listing flows use `useActionState` and `revalidatePath`; follow that same server-action pattern for rule save/reload.
+- Interactive components should use the repo’s `.client.tsx` naming convention.
+- Keep the page server-rendered and the form client-rendered, matching the listing create/detail flow.
+
+### References
+
+- `_bmad-output/planning-artifacts/epics.md` - `Epic 3`, `Story 3.1`, FR18
+- `_bmad-output/planning-artifacts/prd.md` - FR18, FR19, NFR9, NFR10, NFR11, NFR15
+- `_bmad-output/planning-artifacts/architecture.md` - Active MVP boundaries, `src/domain/pricing`, `feature -> domain -> infra`, event responsibilities
+- `_bmad-output/planning-artifacts/ux-design-specification.md` - `AutoAdjustRulePage`, `AutoAdjustRuleSelector`, simplified core flow, accessibility gates
+- `_bmad-output/test-artifacts/test-design-epic-3.md` - R-002, P0 validation, accessible recovery, last-valid-state preservation
+- `_bmad-output/implementation-artifacts/dependency-graph.md` - Story 3.1 ready, Story 3.2 dependency
+- [src/domain/pricing/pricing-suggestion.ts](/C:/Users/ok.works/Projects/PreProduct/src/domain/pricing/pricing-suggestion.ts)
+- [src/shared/contracts/pricing-suggestion.ts](/C:/Users/ok.works/Projects/PreProduct/src/shared/contracts/pricing-suggestion.ts)
+- [src/shared/contracts/events/pricing-suggestion-accepted.v1.ts](/C:/Users/ok.works/Projects/PreProduct/src/shared/contracts/events/pricing-suggestion-accepted.v1.ts)
+- [src/domain/listing/listing.ts](/C:/Users/ok.works/Projects/PreProduct/src/domain/listing/listing.ts)
+- [src/app/listings/[listingId]/page.tsx](/C:/Users/ok.works/Projects/PreProduct/src/app/listings/%5BlistingId%5D/page.tsx)
+- [src/feature/listing/components/listing-form.client.tsx](/C:/Users/ok.works/Projects/PreProduct/src/feature/listing/components/listing-form.client.tsx)
+- [src/feature/listing/components/listing-submit-bar.client.tsx](/C:/Users/ok.works/Projects/PreProduct/src/feature/listing/components/listing-submit-bar.client.tsx)
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5 Codex
+
+### Debug Log References
+
+- `_bmad-output/planning-artifacts/epics.md`
+- `_bmad-output/planning-artifacts/prd.md`
+- `_bmad-output/planning-artifacts/architecture.md`
+- `_bmad-output/planning-artifacts/ux-design-specification.md`
+- `_bmad-output/test-artifacts/test-design-epic-3.md`
+- `_bmad-output/implementation-artifacts/dependency-graph.md`
+- `src/domain/pricing/pricing-suggestion.ts`
+- `src/shared/contracts/pricing-suggestion.ts`
+- `src/shared/contracts/events/pricing-suggestion-accepted.v1.ts`
+- `src/domain/listing/listing.ts`
+- `src/app/listings/[listingId]/page.tsx`
+- `src/feature/listing/components/listing-form.client.tsx`
+- `src/feature/listing/components/listing-submit-bar.client.tsx`
+
+### Completion Notes List
+
+- Story 3.1 context prepared from planning artifacts, Epic 3 test design, and the current pricing/listing codebase.
+- The story is scoped to rule configuration only and leaves execution, history, and event emission to later stories.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/3-1-자동-가격조정-규칙-설정.md`

--- a/_bmad-output/implementation-artifacts/3-1-자동-가격조정-규칙-설정.md
+++ b/_bmad-output/implementation-artifacts/3-1-자동-가격조정-규칙-설정.md
@@ -1,6 +1,6 @@
 # Story 3.1: 자동 가격조정 규칙 설정
 
-Status: ready-for-dev
+Status: review
 
 ## Story
 
@@ -31,26 +31,26 @@ so that 가격 관리를 자동화할 수 있다.
 
 ## Tasks / Subtasks
 
-- [ ] 규칙 도메인 계약과 검증 헬퍼를 추가한다. (AC: 1, 2)
-  - [ ] `src/domain/pricing/auto-adjust-rule.ts`를 생성하고 규칙 입력 스키마, 표시 모델, 검증 헬퍼를 정의한다.
-  - [ ] 기간은 정수 일수, 인하율은 정수 퍼센트, 최저가 하한은 KRW 정수로 다루고, 금액 경계는 `listingPricePolicy`를 재사용한다.
-  - [ ] 잘못된 값과 unsafe 조합에 대한 단위 테스트를 `src/domain/pricing/auto-adjust-rule.test.ts`에 추가한다.
+- [x] 규칙 도메인 계약과 검증 헬퍼를 추가한다. (AC: 1, 2)
+  - [x] `src/domain/pricing/auto-adjust-rule.ts`를 생성하고 규칙 입력 스키마, 표시 모델, 검증 헬퍼를 정의한다.
+  - [x] 기간은 정수 일수, 인하율은 정수 퍼센트, 최저가 하한은 KRW 정수로 다루고, 금액 경계는 `listingPricePolicy`를 재사용한다.
+  - [x] 잘못된 값과 unsafe 조합에 대한 단위 테스트를 `src/domain/pricing/auto-adjust-rule.test.ts`에 추가한다.
 
-- [ ] 규칙 저장 경계와 서버 액션을 구현한다. (AC: 1, 2, 3)
-  - [ ] `src/feature/listing/actions/save-auto-adjust-rule.action.ts`를 생성해 `use server` 경계에서 입력 검증, 저장, 재시도 가능한 form state 반환을 처리한다.
-  - [ ] `src/infra/pricing/auto-adjust-rule.repository.ts` 또는 동등한 infra 저장소를 추가해 page/component에서 직접 persistence를 호출하지 않도록 한다.
-  - [ ] 저장 실패나 검증 실패 시 마지막 유효 규칙을 유지하고, 사용자에게는 복구 가능한 오류만 노출한다.
+- [x] 규칙 저장 경계와 서버 액션을 구현한다. (AC: 1, 2, 3)
+  - [x] `src/feature/listing/actions/save-auto-adjust-rule.action.ts`를 생성해 `use server` 경계에서 입력 검증, 저장, 재시도 가능한 form state 반환을 처리한다.
+  - [x] `src/infra/pricing/auto-adjust-rule.repository.ts` 또는 동등한 infra 저장소를 추가해 page/component에서 직접 persistence를 호출하지 않도록 한다.
+  - [x] 저장 실패나 검증 실패 시 마지막 유효 규칙을 유지하고, 사용자에게는 복구 가능한 오류만 노출한다.
 
-- [ ] AutoAdjustRulePage와 규칙 선택 UI를 추가한다. (AC: 1, 3)
-  - [ ] `src/app/listings/[listingId]/auto-adjust-rule/page.tsx`를 생성해 규칙 설정 화면을 분리한다.
-  - [ ] `src/feature/listing/components/auto-adjust-rule-selector.client.tsx`를 생성해 모바일 우선 단일 컬럼 폼과 MUI 기반 입력/오류 상태를 제공한다.
-  - [ ] listing detail 화면에서 해당 페이지로 이동할 수 있는 진입점을 제공하되, 상태 변경 UI와 규칙 설정 UI는 섞지 않는다.
+- [x] AutoAdjustRulePage와 규칙 선택 UI를 추가한다. (AC: 1, 3)
+  - [x] `src/app/listings/[listingId]/auto-adjust-rule/page.tsx`를 생성해 규칙 설정 화면을 분리한다.
+  - [x] `src/feature/listing/components/auto-adjust-rule-selector.client.tsx`를 생성해 모바일 우선 단일 컬럼 폼과 MUI 기반 입력/오류 상태를 제공한다.
+  - [x] listing detail 화면에서 해당 페이지로 이동할 수 있는 진입점을 제공하되, 상태 변경 UI와 규칙 설정 UI는 섞지 않는다.
 
-- [ ] 테스트를 추가해 Story 3.1의 회귀를 고정한다. (AC: 1, 2, 3)
-  - [ ] `tests/e2e/auto-adjust-rule-flow.spec.ts`를 추가해 유효 규칙 저장, invalid input recovery, reopen/prefill 흐름을 검증한다.
-  - [ ] 규칙 validator 단위 테스트에서 기간/인하율/하한 경계값과 이전 유효 상태 보존을 검증한다.
-  - [ ] 접근성 검증은 `role`, `label`, focus order, `aria-live` 기준으로 확인한다.
-  - [ ] 이 스토리에서는 scheduler, history view, event emission, `pricing.auto_adjust.applied.v1` 계약을 구현하지 않는다.
+- [x] 테스트를 추가해 Story 3.1의 회귀를 고정한다. (AC: 1, 2, 3)
+  - [x] `tests/e2e/auto-adjust-rule-flow.spec.ts`를 추가해 유효 규칙 저장, invalid input recovery, reopen/prefill 흐름을 검증한다.
+  - [x] 규칙 validator 단위 테스트에서 기간/인하율/하한 경계값과 이전 유효 상태 보존을 검증한다.
+  - [x] 접근성 검증은 `role`, `label`, focus order, `aria-live` 기준으로 확인한다.
+  - [x] 이 스토리에서는 scheduler, history view, event emission, `pricing.auto_adjust.applied.v1` 계약을 구현하지 않는다.
 
 ## Dev Notes
 
@@ -188,12 +188,39 @@ GPT-5 Codex
 - `src/app/listings/[listingId]/page.tsx`
 - `src/feature/listing/components/listing-form.client.tsx`
 - `src/feature/listing/components/listing-submit-bar.client.tsx`
+- `pnpm exec prisma generate`
+- `pnpm exec prisma db push`
+- `pnpm unit --runTestsByPath src/domain/pricing/auto-adjust-rule.test.ts src/feature/listing/actions/save-auto-adjust-rule.action.test.ts src/infra/pricing/auto-adjust-rule.repository.test.ts`
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test:e2e tests/e2e/auto-adjust-rule-flow.spec.ts --project=chromium`
 
 ### Completion Notes List
 
 - Story 3.1 context prepared from planning artifacts, Epic 3 test design, and the current pricing/listing codebase.
 - The story is scoped to rule configuration only and leaves execution, history, and event emission to later stories.
+- Added the listing-scoped auto price adjustment rule contract, validation helper, display model, and last-valid-state form preservation behavior.
+- Added Prisma-backed persistence for one active rule per listing, plus a server-action handler that validates before persistence and exposes only recoverable errors.
+- Added a separate AutoAdjustRulePage and MUI client selector with explicit labels, `role="status"`, validation `role="alert"`, and a detail-page entry/summary.
+- Converted the Story 3.1 red-phase handoff into runnable unit/action/repository and E2E coverage for save, invalid recovery, reopen/prefill, and keyboard focus order.
+- Node engine warning observed during checks: repo requires Node `>=24.14.1 <25`; local shell used Node `v22.18.0`. Checks still completed.
 
 ### File List
 
 - `_bmad-output/implementation-artifacts/3-1-자동-가격조정-규칙-설정.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `prisma/schema.prisma`
+- `src/app/listings/[listingId]/auto-adjust-rule/page.tsx`
+- `src/app/listings/[listingId]/page.tsx`
+- `src/domain/pricing/auto-adjust-rule.test.ts`
+- `src/domain/pricing/auto-adjust-rule.ts`
+- `src/feature/listing/actions/save-auto-adjust-rule.action.test.ts`
+- `src/feature/listing/actions/save-auto-adjust-rule.action.ts`
+- `src/feature/listing/components/auto-adjust-rule-selector.client.tsx`
+- `src/infra/pricing/auto-adjust-rule.repository.test.ts`
+- `src/infra/pricing/auto-adjust-rule.repository.ts`
+- `tests/e2e/auto-adjust-rule-flow.spec.ts`
+
+### Change Log
+
+- 2026-04-22: Implemented Story 3.1 automatic price-adjustment rule setup and moved story to review.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -19,6 +19,7 @@
 # Story Status:
 #   - backlog: Story only exists in epic file
 #   - ready-for-dev: Story file created in stories folder
+#   - atdd-done: Red-phase ATDD artifacts are complete and ready for implementation handoff
 #   - in-progress: Developer actively working on implementation
 #   - review: Ready for code review (via Dev's code-review workflow)
 #   - done: Story completed
@@ -61,7 +62,7 @@ development_status:
 
   # Epic 3: 자동 가격조정 및 업데이트 신호
   epic-3: in-progress
-  3-1-자동-가격조정-규칙-설정: ready-for-dev
+  3-1-자동-가격조정-규칙-설정: atdd-done
   3-2-규칙-기반-자동-가격조정-실행-및-사유-기록: backlog
   3-3-가격-변경-이력-조회-및-최소-신호-수집: backlog
   epic-3-retrospective: optional

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -62,7 +62,7 @@ development_status:
 
   # Epic 3: 자동 가격조정 및 업데이트 신호
   epic-3: in-progress
-  3-1-자동-가격조정-규칙-설정: review
+  3-1-자동-가격조정-규칙-설정: done
   3-2-규칙-기반-자동-가격조정-실행-및-사유-기록: backlog
   3-3-가격-변경-이력-조회-및-최소-신호-수집: backlog
   epic-3-retrospective: optional

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -62,7 +62,7 @@ development_status:
 
   # Epic 3: 자동 가격조정 및 업데이트 신호
   epic-3: in-progress
-  3-1-자동-가격조정-규칙-설정: atdd-done
+  3-1-자동-가격조정-규칙-설정: review
   3-2-규칙-기반-자동-가격조정-실행-및-사유-기록: backlog
   3-3-가격-변경-이력-조회-및-최소-신호-수집: backlog
   epic-3-retrospective: optional

--- a/_bmad-output/test-artifacts/red-phase/story-3-1/atdd-checklist-3-1-auto-price-adjustment-rule-setup.md
+++ b/_bmad-output/test-artifacts/red-phase/story-3-1/atdd-checklist-3-1-auto-price-adjustment-rule-setup.md
@@ -94,4 +94,3 @@ generatedTestFiles:
 - TDD compliance: generated executable scenarios use `test.skip()` and contain concrete assertions rather than placeholders.
 - CLI browser recording: not used; target component and selectors do not exist yet, so selector verification is documented as implementation requirements.
 - Temp artifacts: stored under `_bmad-output/test-artifacts/red-phase/story-3-1/`, not random temp paths.
-

--- a/_bmad-output/test-artifacts/red-phase/story-3-1/atdd-checklist-3-1-auto-price-adjustment-rule-setup.md
+++ b/_bmad-output/test-artifacts/red-phase/story-3-1/atdd-checklist-3-1-auto-price-adjustment-rule-setup.md
@@ -1,0 +1,97 @@
+---
+stepsCompleted:
+  - step-01-preflight-and-context
+  - step-02-generation-mode
+  - step-03-test-strategy
+  - step-04-generate-tests
+  - step-04c-aggregate
+  - step-05-validate-and-complete
+lastStep: step-05-validate-and-complete
+lastSaved: "2026-04-22"
+workflowType: testarch-atdd
+storyId: "3.1"
+storyKey: "3-1-auto-price-adjustment-rule-setup"
+storyTitle: "자동 가격조정 규칙 설정"
+storyFile: "_bmad-output/implementation-artifacts/3-1-자동-가격조정-규칙-설정.md"
+inputDocuments:
+  - "_bmad-output/implementation-artifacts/3-1-자동-가격조정-규칙-설정.md"
+  - "_bmad-output/test-artifacts/test-design-epic-3.md"
+  - "_bmad-output/planning-artifacts/epics.md"
+  - "_bmad-output/planning-artifacts/prd.md"
+  - "_bmad-output/planning-artifacts/architecture.md"
+generatedTestFiles:
+  - "_bmad-output/test-artifacts/red-phase/story-3-1/tests/domain/auto-adjust-rule.red.test.ts"
+  - "_bmad-output/test-artifacts/red-phase/story-3-1/tests/e2e/auto-adjust-rule-flow.spec.ts"
+---
+
+# ATDD Checklist: Story 3.1 자동 가격조정 규칙 설정
+
+## TDD Red Phase
+
+- 상태: 완료
+- 생성 방식: AI generation, sequential fallback
+- 감지 스택: fullstack
+- 테스트 프레임워크: Playwright 1.59.1, Jest 30.3.0, TypeScript 6.0.3
+- Red phase 원칙: 모든 테스트는 `test.skip()` 기반으로 생성했다. 구현 후 skip을 제거하면 현재 없는 `auto-adjust-rule` 도메인/페이지/서버 액션 때문에 실패해야 한다.
+
+## Acceptance Criteria Coverage
+
+| AC | 시나리오 | 테스트 파일 | 우선순위 |
+| --- | --- | --- | --- |
+| AC1 | 유효한 주기/인하율/최저가 하한 저장 시 규칙이 활성 규칙으로 반영됨 | `_bmad-output/test-artifacts/red-phase/story-3-1/tests/e2e/auto-adjust-rule-flow.spec.ts` | P0 |
+| AC2 | 유효하지 않은 규칙 제출 시 필드 오류와 복구 안내를 표시하고 마지막 유효 상태를 유지함 | `_bmad-output/test-artifacts/red-phase/story-3-1/tests/e2e/auto-adjust-rule-flow.spec.ts` | P0 |
+| AC2 | 규칙 도메인 검증이 invalid period/discount/floor 조합을 거부함 | `_bmad-output/test-artifacts/red-phase/story-3-1/tests/domain/auto-adjust-rule.red.test.ts` | P0 |
+| AC3 | 재진입 시 현재 활성 규칙이 미리 채워지고 키보드 접근성이 유지됨 | `_bmad-output/test-artifacts/red-phase/story-3-1/tests/e2e/auto-adjust-rule-flow.spec.ts` | P1 |
+
+## Generated Files
+
+- `_bmad-output/test-artifacts/red-phase/story-3-1/tests/domain/auto-adjust-rule.red.test.ts`
+- `_bmad-output/test-artifacts/red-phase/story-3-1/tests/e2e/auto-adjust-rule-flow.spec.ts`
+- `_bmad-output/test-artifacts/red-phase/story-3-1/atdd-checklist-3-1-auto-price-adjustment-rule-setup.md`
+
+## Required Implementation Hooks
+
+- `src/domain/pricing/auto-adjust-rule.ts`
+- `src/domain/pricing/auto-adjust-rule.test.ts`
+- `src/feature/listing/actions/save-auto-adjust-rule.action.ts`
+- `src/feature/listing/components/auto-adjust-rule-selector.client.tsx`
+- `src/app/listings/[listingId]/auto-adjust-rule/page.tsx`
+- `src/app/listings/[listingId]/page.tsx` for the entry link and summary surface only
+
+## Required Selectors And Accessible Names
+
+- `data-testid="auto-adjust-rule-form"`
+- `data-testid="auto-adjust-rule-active-summary"`
+- `data-testid="auto-adjust-rule-save-status"`
+- Label `주기(일)`
+- Label `인하율(%)`
+- Label `최저가 하한 (원)`
+- Button `규칙 저장`
+- Status region `role="status"` for polite success/reopen feedback
+- Alert region `role="alert"` for recoverable validation errors
+
+## Mock And Fixture Requirements
+
+- Rule values can remain deterministic and local; no scheduler, queue, or event pipeline is required for Story 3.1.
+- The save action should preserve the last valid rule in form state when validation fails.
+- Revisit/prefill can be asserted through the route page itself without DB-backed history.
+
+## Red-Green-Refactor Handoff
+
+1. Implement the domain rule contract and validation helper first.
+2. Implement the save-rule server action and persistence boundary.
+3. Implement the rule settings page and client selector with accessible labels and summary text.
+4. Remove `test.skip()` from the generated red-phase tests during green phase.
+5. Run focused checks:
+   - `pnpm unit`
+   - Playwright check for `_bmad-output/test-artifacts/red-phase/story-3-1/tests/e2e/auto-adjust-rule-flow.spec.ts`
+
+## Validation
+
+- Prerequisites satisfied: story has explicit ACs, `playwright.config.ts` exists, `package.json` has Playwright/Jest/TypeScript.
+- Existing patterns reviewed: listing form/action state handling, prior ATDD checklist structure, selector resilience, and the Epic 3 test design.
+- Knowledge applied: Epic 3 risk R-002, invalid config recovery, and last-valid-state preservation.
+- TDD compliance: generated executable scenarios use `test.skip()` and contain concrete assertions rather than placeholders.
+- CLI browser recording: not used; target component and selectors do not exist yet, so selector verification is documented as implementation requirements.
+- Temp artifacts: stored under `_bmad-output/test-artifacts/red-phase/story-3-1/`, not random temp paths.
+

--- a/_bmad-output/test-artifacts/red-phase/story-3-1/tests/domain/auto-adjust-rule.red.test.ts
+++ b/_bmad-output/test-artifacts/red-phase/story-3-1/tests/domain/auto-adjust-rule.red.test.ts
@@ -1,0 +1,66 @@
+describe("Story 3.1 auto-adjust rule domain contract (ATDD RED)", () => {
+  test.skip("[P0] accepts a valid listing-scoped rule and normalizes its values", async () => {
+    // Given: a valid rule payload for a single listing.
+    // @ts-ignore -- ATDD red phase imports the target story module before implementation.
+    const { autoAdjustRuleInputSchema } = await import(
+      "@/domain/pricing/auto-adjust-rule"
+    );
+
+    const parsed = autoAdjustRuleInputSchema.parse({
+      listingId: "b9c0d2d8-20f8-4d2e-b4a8-84dba2be8e1b",
+      periodDays: "14",
+      discountRatePercent: "8",
+      floorPriceKrw: "1200000"
+    });
+
+    expect(parsed).toEqual({
+      listingId: "b9c0d2d8-20f8-4d2e-b4a8-84dba2be8e1b",
+      periodDays: 14,
+      discountRatePercent: 8,
+      floorPriceKrw: 1_200_000
+    });
+  });
+
+  test.skip("[P0] rejects a zero period with a field-specific recovery message", async () => {
+    // Given: the period is not a positive integer day count.
+    // @ts-ignore -- ATDD red phase imports the target story module before implementation.
+    const { autoAdjustRuleInputSchema } = await import(
+      "@/domain/pricing/auto-adjust-rule"
+    );
+
+    expect(() =>
+      autoAdjustRuleInputSchema.parse({
+        listingId: "b9c0d2d8-20f8-4d2e-b4a8-84dba2be8e1b",
+        periodDays: "0",
+        discountRatePercent: "8",
+        floorPriceKrw: "1200000"
+      })
+    ).toThrow();
+  });
+
+  test.skip("[P0] rejects discount and floor values outside the rule policy", async () => {
+    // Given: the rule violates the pricing floor or discount percentage policy.
+    // @ts-ignore -- ATDD red phase imports the target story module before implementation.
+    const { autoAdjustRuleInputSchema } = await import(
+      "@/domain/pricing/auto-adjust-rule"
+    );
+
+    expect(() =>
+      autoAdjustRuleInputSchema.parse({
+        listingId: "b9c0d2d8-20f8-4d2e-b4a8-84dba2be8e1b",
+        periodDays: "14",
+        discountRatePercent: "101",
+        floorPriceKrw: "1200000"
+      })
+    ).toThrow();
+
+    expect(() =>
+      autoAdjustRuleInputSchema.parse({
+        listingId: "b9c0d2d8-20f8-4d2e-b4a8-84dba2be8e1b",
+        periodDays: "14",
+        discountRatePercent: "8",
+        floorPriceKrw: "0"
+      })
+    ).toThrow();
+  });
+});

--- a/_bmad-output/test-artifacts/red-phase/story-3-1/tests/e2e/auto-adjust-rule-flow.spec.ts
+++ b/_bmad-output/test-artifacts/red-phase/story-3-1/tests/e2e/auto-adjust-rule-flow.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test } from "@playwright/test";
+
+const listingId = "b9c0d2d8-20f8-4d2e-b4a8-84dba2be8e1b";
+const rulePagePath = `/listings/${listingId}/auto-adjust-rule`;
+
+const validRule = {
+  periodDays: "14",
+  discountRatePercent: "8",
+  floorPriceKrw: "1200000"
+};
+
+const invalidRule = {
+  periodDays: "0",
+  discountRatePercent: "101",
+  floorPriceKrw: "0"
+};
+
+async function fillRuleForm(
+  page: import("@playwright/test").Page,
+  values: typeof validRule
+) {
+  await page.getByLabel("주기(일)", { exact: true }).fill(values.periodDays);
+  await page.getByLabel("인하율(%)", { exact: true }).fill(
+    values.discountRatePercent
+  );
+  await page.getByLabel("최저가 하한 (원)", { exact: true }).fill(
+    values.floorPriceKrw
+  );
+}
+
+test.describe("Story 3.1 auto-adjust rule flow (ATDD RED)", () => {
+  test.skip("[P0] saves a valid rule and marks it as the active rule", async ({ page }) => {
+    await page.goto(rulePagePath);
+    await fillRuleForm(page, validRule);
+    await page.getByRole("button", { name: "규칙 저장" }).click();
+
+    await expect(page.getByRole("alert")).toContainText("규칙이 저장되었습니다");
+    await expect(page.getByTestId("auto-adjust-rule-active-summary")).toContainText(
+      "14일"
+    );
+    await expect(page.getByTestId("auto-adjust-rule-active-summary")).toContainText(
+      "8%"
+    );
+    await expect(page.getByTestId("auto-adjust-rule-active-summary")).toContainText(
+      "1,200,000원"
+    );
+    await expect(page.getByLabel("주기(일)", { exact: true })).toHaveValue("14");
+    await expect(page.getByLabel("인하율(%)", { exact: true })).toHaveValue("8");
+    await expect(page.getByLabel("최저가 하한 (원)", { exact: true })).toHaveValue(
+      "1200000"
+    );
+  });
+
+  test.skip(
+    "[P0] keeps the last valid rule in place when an invalid update is submitted",
+    async ({ page }) => {
+      await page.goto(rulePagePath);
+      await fillRuleForm(page, validRule);
+      await page.getByRole("button", { name: "규칙 저장" }).click();
+
+      await fillRuleForm(page, invalidRule);
+      await page.getByRole("button", { name: "규칙 저장" }).click();
+
+      await expect(page.getByRole("alert")).toContainText("유효성 검증");
+      await expect(page.getByLabel("주기(일)", { exact: true })).toHaveValue("14");
+      await expect(page.getByLabel("인하율(%)", { exact: true })).toHaveValue("8");
+      await expect(page.getByLabel("최저가 하한 (원)", { exact: true })).toHaveValue(
+        "1200000"
+      );
+      await expect(page.getByTestId("auto-adjust-rule-active-summary")).toContainText(
+        "14일"
+      );
+      await expect(page.getByTestId("auto-adjust-rule-active-summary")).toContainText(
+        "8%"
+      );
+    }
+  );
+
+  test.skip(
+    "[P1] reloads the saved rule on revisit and preserves keyboard-safe focus order",
+    async ({ page }) => {
+      await page.goto(rulePagePath);
+      await fillRuleForm(page, validRule);
+      await page.getByRole("button", { name: "규칙 저장" }).click();
+
+      await page.goto(`/listings/${listingId}`);
+      await page.goto(rulePagePath);
+
+      await expect(page.getByLabel("주기(일)", { exact: true })).toHaveValue("14");
+      await expect(page.getByLabel("인하율(%)", { exact: true })).toHaveValue("8");
+      await expect(page.getByLabel("최저가 하한 (원)", { exact: true })).toHaveValue(
+        "1200000"
+      );
+      await expect(page.getByRole("status")).toContainText("현재 활성 규칙");
+
+      await page.keyboard.press("Tab");
+      await expect(page.getByLabel("주기(일)", { exact: true })).toBeFocused();
+      await page.keyboard.press("Tab");
+      await expect(page.getByLabel("인하율(%)", { exact: true })).toBeFocused();
+      await page.keyboard.press("Tab");
+      await expect(page.getByLabel("최저가 하한 (원)", { exact: true })).toBeFocused();
+    }
+  );
+});

--- a/_bmad-output/test-artifacts/test-review.md
+++ b/_bmad-output/test-artifacts/test-review.md
@@ -9,90 +9,92 @@ lastStep: "step-04-generate-report"
 lastSaved: "2026-04-22"
 workflowType: "testarch-test-review"
 inputDocuments:
-  - "_bmad-output/implementation-artifacts/2-3-PriceSuggestionCard-기반-추천가-수용-수정-확정.md"
-  - "_bmad-output/test-artifacts/atdd-checklist-2.3.md"
+  - "_bmad-output/implementation-artifacts/3-1-자동-가격조정-규칙-설정.md"
+  - "_bmad-output/test-artifacts/test-design-epic-3.md"
+  - "_bmad-output/test-artifacts/red-phase/story-3-1/atdd-checklist-3-1-auto-price-adjustment-rule-setup.md"
   - "playwright.config.ts"
   - "package.json"
-  - "tests/e2e/price-suggestion-card-flow.spec.ts"
-  - "tests/e2e/listing-registration.spec.ts"
-  - "tests/e2e/photo-uploader-flow.spec.ts"
-  - "tests/contracts/pricing-suggestion-accepted.v1.contract.test.ts"
-  - "src/domain/pricing/pricing-suggestion.test.ts"
+  - "src/domain/pricing/auto-adjust-rule.test.ts"
+  - "src/feature/listing/actions/save-auto-adjust-rule.action.test.ts"
+  - "src/infra/pricing/auto-adjust-rule.repository.test.ts"
+  - "tests/e2e/auto-adjust-rule-flow.spec.ts"
 ---
 
-# Test Review: Story 2.3 PriceSuggestionCard 기반 추천가 수용/수정 확정
+# Test Review: Story 3.1 자동 가격조정 규칙 설정
 
 **Date:** 2026-04-22
-**Scope:** Story 2.3 focused test review
-**Stack:** Next.js App Router, React, Jest unit/contract tests, Playwright E2E
+**Scope:** Story 3.1 focused test review
+**Stack:** Next.js App Router, React, Jest unit/action/repository tests, Playwright E2E
 **Recommendation:** Approve
-**Coverage note:** `test-review`는 coverage를 점수화하지 않는다. 요구사항 추적과 coverage gate는 `trace` 워크플로우에서 다룬다.
+**Coverage note:** `test-review` does not score requirements coverage. Requirements trace and coverage gates belong to the trace workflow.
 
 ## Score Summary
 
 | Dimension | Score | Grade | Notes |
 | --- | ---: | --- | --- |
-| Determinism | 96 | A | No hard waits, no random data, fixed event timestamp in contract test |
-| Isolation | 94 | A | UI tests use per-test page state; auth fixture is localStorage-scoped through `addInitScript` |
-| Maintainability | 93 | A | Shared listing-basis helper now accepts the title used by submit assertions |
-| Performance | 95 | A | Focused Playwright run completed in 12.1s; no serial constraints or expensive repeated setup beyond DB-gated submit test |
-| **Overall** | **95** | **A** | Review finding applied and all focused gates passed |
+| Determinism | 95 | A | No hard waits; E2E uses stable labels/test ids and scoped role locators |
+| Isolation | 93 | A | Unit tests inject action/repository dependencies; DB-backed E2E creates its own listing |
+| Maintainability | 94 | A | Rule flow helpers keep form setup centralized and assertions are acceptance-facing |
+| Performance | 94 | A | Focused unit and E2E checks run quickly; no serial Playwright dependency added |
+| **Overall** | **94** | **A** | Review findings applied and focused gates passed |
 
 ## Findings Applied
 
-### HIGH: Story E2E did not prove accepted suggested price submission
+### MEDIUM: E2E did not assert field-level recovery guidance
 
-- **Evidence:** `tests/e2e/price-suggestion-card-flow.spec.ts` asserted that accepting the suggestion updated the read-only `priceKrw` field, but it did not submit the form and verify the persisted listing detail price. The story testing requirement explicitly calls for final `priceKrw` submission reflection.
-- **Risk:** A regression could keep the UI confirmation state green while breaking the actual `FormData` submit path used by `createListing`.
-- **Fix:** Added a DB-gated focused E2E at `tests/e2e/price-suggestion-card-flow.spec.ts:19` that accepts the suggested price, submits the listing, and verifies the detail page price is `1,240,000원`.
-- **Follow-up found during fix:** The first draft of the new test changed the title after suggestion generation, correctly triggering stale revision protection. The helper now accepts the final title up front so the submission assertion exercises the valid accept path.
+- **Evidence:** `tests/e2e/auto-adjust-rule-flow.spec.ts` asserted the validation alert and preserved values after invalid input, but did not prove field-specific errors or the recovery guide were rendered.
+- **Risk:** The server action could keep rejecting invalid input while the user-facing field guidance regressed.
+- **Fix:** Added E2E assertions for the validation alert recovery guide and the period, discount, and floor helper texts.
+
+### MEDIUM: Repository read path lacked unit coverage for reopen/prefill behavior
+
+- **Evidence:** `src/infra/pricing/auto-adjust-rule.repository.test.ts` covered upsert and write failures, but not `findActiveByListingId`, which is the persistence path used by the rule setup page on revisit.
+- **Risk:** Prefill behavior could break independently of save behavior.
+- **Fix:** Added repository tests for active rule mapping and disabled-rule exclusion.
+
+### LOW: No-active-rule invalid recovery branch was implicit only
+
+- **Evidence:** Action tests covered preserving the last valid rule on invalid input, but not the first-save invalid case where there is no last valid rule to restore.
+- **Risk:** A first-time user could lose attempted values needed to correct the form.
+- **Fix:** Added an action test proving attempted invalid values remain available when no active rule exists yet.
 
 ## Test Inventory Reviewed
 
-| File | Lines | Framework | Tests | Review Notes |
-| --- | ---: | --- | ---: | --- |
-| `tests/e2e/price-suggestion-card-flow.spec.ts` | 150 | Playwright | 6 | Accept, submit/detail persistence, manual edit, validation, auth recovery, stale revision |
-| `tests/contracts/pricing-suggestion-accepted.v1.contract.test.ts` | 45 | Jest | 3 | Canonical fixture, deterministic event id, required revision/idempotency fields |
-| `src/domain/pricing/pricing-suggestion.test.ts` | 46 | Jest | 2 | Deterministic basis revision, suggestion amount, client price policy guard |
-| `tests/e2e/listing-registration.spec.ts` | 123 | Playwright | 2 | Existing DB-backed submit/detail path remains aligned with price card manual confirmation |
-| `tests/e2e/photo-uploader-flow.spec.ts` | 429 | Playwright | 9 | Existing fallback completion tests updated by dev to confirm manual price before submit |
+| File | Framework | Review Notes |
+| --- | --- | --- |
+| `src/domain/pricing/auto-adjust-rule.test.ts` | Jest | Valid normalization, invalid boundaries, unsafe floor/current-price combination, display helpers |
+| `src/feature/listing/actions/save-auto-adjust-rule.action.test.ts` | Jest | Save success, invalid recovery, retryable persistence failure, first-save invalid recovery |
+| `src/infra/pricing/auto-adjust-rule.repository.test.ts` | Jest | One active rule upsert, active read/prefill mapping, disabled rule exclusion, FK and retryable failures |
+| `tests/e2e/auto-adjust-rule-flow.spec.ts` | Playwright | Save, invalid recovery, field guidance, detail summary, revisit prefill, keyboard focus order |
 
 ## Quality Criteria Assessment
 
 | Criterion | Status | Notes |
 | --- | --- | --- |
-| Network-first pattern | PASS | AI route mocks in adjacent regression tests are installed before upload/navigation triggers |
-| Hard waits | PASS | No `waitForTimeout` or fixed sleeps in Story 2.3 active tests |
-| Determinism | PASS | Stable test data; event deterministic checks use fixed inputs |
-| Isolation | PASS | No test order dependency; DB-backed submit test is skipped when `DATABASE_URL` is absent |
-| Fixture/helper use | PASS | Shared `fillConfirmedListingBasis` reduces repeated form setup |
-| Explicit assertions | PASS | Price card tests assert field values, event id absence/presence, stale/auth alerts, and detail price |
-| Performance | PASS | Focused Playwright run is short; no unnecessary serial mode |
-| Priority markers | WARN | Active file names do not encode P0/P1 markers, but the ATDD red-phase artifacts retain priority labels |
-
-## Best Practices Found
-
-- The stale suggestion test mutates core listing fields after suggestion generation and verifies no event id is produced.
-- The auth recovery test uses a typed fixture branch and asserts seller input is retained without creating an event.
-- Contract tests assert both canonical schema acceptance and deterministic producer helper behavior.
-- Client/domain price policy tests compare against the listing creation schema so the UI guard does not drift looser than server validation.
+| Hard waits | PASS | No `waitForTimeout` or fixed sleep usage |
+| Determinism | PASS | Stable listing data, scoped role locators, no randomness |
+| Isolation | PASS | Unit tests inject dependencies; E2E creates a fresh listing |
+| Network-first pattern | N/A | Story 3.1 flow is DB/server-action based and does not mock network routes |
+| Fixture/helper use | PASS | E2E uses local helpers for listing creation and form filling |
+| Explicit assertions | PASS | Tests assert persisted active state, field errors, recovery guide, prefill, and focus order |
+| Performance | PASS | Focused checks are short and parallel-safe |
+| Priority markers | WARN | Active tests do not encode P0/P1 IDs in names; red-phase ATDD artifacts retain priority mapping |
 
 ## Validation
 
-- `pnpm typecheck` passed. Node engine warning remains: current `v22.18.0`, package requires `>=24.14.1 <25`.
-- `pnpm lint` passed with the same Node engine warning.
-- `pnpm unit` passed: 14 suites, 45 tests.
-- `pnpm contract` passed: 4 suites, 15 tests.
-- `pnpm perf-budget` passed, including `next build` and budget probe. Same Node engine warning.
-- Focused Playwright passed: `PLAYWRIGHT_WEB_SERVER_COMMAND="pnpm dev" pnpm exec playwright test tests/e2e/price-suggestion-card-flow.spec.ts --project=chromium` -> 6 passed, 5 ATDD red-phase tests skipped.
+- `pnpm unit --runTestsByPath src/domain/pricing/auto-adjust-rule.test.ts src/feature/listing/actions/save-auto-adjust-rule.action.test.ts src/infra/pricing/auto-adjust-rule.repository.test.ts` passed: 3 suites, 14 tests.
+- `PLAYWRIGHT_WEB_SERVER_COMMAND="pnpm dev" pnpm test:e2e tests/e2e/auto-adjust-rule-flow.spec.ts --project=chromium` passed: 1 active test passed, 3 red-phase tests skipped.
+- `pnpm typecheck` passed.
+- `pnpm lint` passed.
+- Local shell warning remains: package requires Node `>=24.14.1 <25`; local shell used Node `v22.18.0`.
 - Playwright/Next emitted `NO_COLOR` ignored warnings due to `FORCE_COLOR`; not test-failing.
 
 ## Residual Risk
 
-- Full Playwright suite was not rerun in this review; focused Story 2.3 E2E plus related unit/contract/perf gates passed.
-- Local shell Node remains below the package engine range. CI/release should use Node `>=24.14.1 <25`.
-- The DB-backed submit assertion requires a reachable `DATABASE_URL`; without it, the test is intentionally skipped like existing listing registration E2E.
+- Full unit and Playwright suites were not rerun; this review ran focused Story 3.1 checks plus static gates.
+- DB-backed E2E uses the configured/default `DATABASE_URL`; environments without a reachable database must keep the same intentional skip behavior or provide a test database.
+- Scheduler, automatic price mutation, history, and `pricing.auto_adjust.applied.v1` coverage remain out of scope for Story 3.1 and belong to later Epic 3 stories.
 
 ## Decision
 
-**Approve.** The main review gap was a missing persisted submission assertion for accepted suggested price. That test is now present, verified, and scoped to the existing DB-backed E2E pattern. No blocking test quality issues remain.
+**Approve.** The concrete test-review gaps were addressed with focused test additions. No blocking Story 3.1 test quality issue remains.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,4 +16,17 @@ model Listing {
   currentStatus     String   @default("판매중")
   createdAt         DateTime @default(now())
   updatedAt         DateTime @updatedAt
+  autoAdjustRule    AutoAdjustRule?
+}
+
+model AutoAdjustRule {
+  id                  String   @id @default(uuid()) @db.Uuid
+  listingId           String   @unique @db.Uuid
+  listing             Listing  @relation(fields: [listingId], references: [id], onDelete: Cascade)
+  periodDays          Int
+  discountRatePercent Int
+  floorPriceKrw       Int
+  enabled             Boolean  @default(true)
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
 }

--- a/src/app/listings/[listingId]/auto-adjust-rule/page.tsx
+++ b/src/app/listings/[listingId]/auto-adjust-rule/page.tsx
@@ -1,0 +1,102 @@
+import { revalidatePath } from "next/cache";
+import { notFound } from "next/navigation";
+import { Box, Button, Container, Stack, Typography } from "@mui/material";
+
+import { listingIdSchema } from "@/domain/listing/listing";
+import { getListingById } from "@/domain/listing/listing.service";
+import {
+  createInitialSaveAutoAdjustRuleFormState,
+  getActiveAutoAdjustRuleForListing,
+  handleSaveAutoAdjustRuleSubmission,
+  saveActiveAutoAdjustRuleForListing,
+  type SaveAutoAdjustRuleFormState
+} from "@/feature/listing/actions/save-auto-adjust-rule.action";
+import { AutoAdjustRuleSelector } from "@/feature/listing/components/auto-adjust-rule-selector.client";
+import { getListingRepository } from "@/infra/listing/listing.repository";
+
+type AutoAdjustRulePageProps = {
+  params: Promise<{
+    listingId: string;
+  }>;
+};
+
+export default async function AutoAdjustRulePage({
+  params
+}: AutoAdjustRulePageProps) {
+  const parsedParams = listingIdSchema.safeParse((await params).listingId);
+
+  if (!parsedParams.success) {
+    notFound();
+  }
+
+  const listing = await getListingById(
+    {
+      listingRepository: getListingRepository()
+    },
+    parsedParams.data
+  );
+
+  if (!listing) {
+    notFound();
+  }
+
+  const resolvedListing = listing;
+  const activeRule = await getActiveAutoAdjustRuleForListing(resolvedListing.id);
+  const initialState = createInitialSaveAutoAdjustRuleFormState(activeRule);
+
+  async function saveAutoAdjustRuleFormAction(
+    previousState: SaveAutoAdjustRuleFormState,
+    formData: FormData
+  ): Promise<SaveAutoAdjustRuleFormState> {
+    "use server";
+
+    const result = await handleSaveAutoAdjustRuleSubmission(
+      {
+        saveAutoAdjustRule: saveActiveAutoAdjustRuleForListing
+      },
+      resolvedListing.id,
+      resolvedListing.priceKrw,
+      previousState,
+      formData
+    );
+
+    if (result.submissionStatus === "success") {
+      revalidatePath(`/listings/${resolvedListing.id}`);
+      revalidatePath(`/listings/${resolvedListing.id}/auto-adjust-rule`);
+    }
+
+    return result;
+  }
+
+  return (
+    <Box sx={{ py: { xs: 4, md: 8 } }}>
+      <Container maxWidth="sm">
+        <Stack spacing={3}>
+          <Stack spacing={1}>
+            <Typography component="h1" variant="h2">
+              자동 가격조정 규칙
+            </Typography>
+            <Typography color="text.secondary">
+              {resolvedListing.title}의 가격조정 주기, 인하율, 최저가 하한을
+              설정합니다.
+            </Typography>
+          </Stack>
+
+          <AutoAdjustRuleSelector
+            action={saveAutoAdjustRuleFormAction}
+            initialState={initialState}
+          />
+
+          <Button
+            href={`/listings/${resolvedListing.id}`}
+            variant="outlined"
+            sx={{ alignSelf: "flex-start", minHeight: 44 }}
+          >
+            매물 상세로 돌아가기
+          </Button>
+        </Stack>
+      </Container>
+    </Box>
+  );
+}
+

--- a/src/app/listings/[listingId]/auto-adjust-rule/page.tsx
+++ b/src/app/listings/[listingId]/auto-adjust-rule/page.tsx
@@ -99,4 +99,3 @@ export default async function AutoAdjustRulePage({
     </Box>
   );
 }
-

--- a/src/app/listings/[listingId]/page.tsx
+++ b/src/app/listings/[listingId]/page.tsx
@@ -19,6 +19,7 @@ import {
   handleUpdateListingStatusSubmission,
   type UpdateListingStatusFormState
 } from "@/feature/listing/actions/update-listing-status.action";
+import { getActiveAutoAdjustRuleForListing } from "@/feature/listing/actions/save-auto-adjust-rule.action";
 import { ListingStatusForm } from "@/feature/listing/components/listing-status-form.client";
 import { getListingRepository } from "@/infra/listing/listing.repository";
 
@@ -69,6 +70,9 @@ export default async function ListingDetailPage({
   }
 
   const resolvedListing = listing;
+  const activeAutoAdjustRule = await getActiveAutoAdjustRuleForListing(
+    resolvedListing.id
+  );
 
   async function updateListingStatusFormAction(
     previousState: UpdateListingStatusFormState,
@@ -155,6 +159,32 @@ export default async function ListingDetailPage({
                 <Typography data-testid="listing-detail-price">
                   {priceFormatter.format(resolvedListing.priceKrw)}원
                 </Typography>
+              </Stack>
+
+              <Divider />
+
+              <Stack
+                direction={{ xs: "column", sm: "row" }}
+                spacing={2}
+                sx={{ justifyContent: "space-between", alignItems: { sm: "center" } }}
+              >
+                <Stack spacing={0.75}>
+                  <Typography variant="overline">자동 가격조정</Typography>
+                  <Typography data-testid="listing-detail-auto-adjust-rule">
+                    {activeAutoAdjustRule
+                      ? `${activeAutoAdjustRule.periodDays}일마다 ${activeAutoAdjustRule.discountRatePercent}% 인하, 최저 ${priceFormatter.format(
+                          activeAutoAdjustRule.floorPriceKrw
+                        )}원`
+                      : "아직 설정된 규칙이 없습니다."}
+                  </Typography>
+                </Stack>
+                <Button
+                  href={`/listings/${resolvedListing.id}/auto-adjust-rule`}
+                  variant="outlined"
+                  sx={{ alignSelf: { xs: "flex-start", sm: "center" } }}
+                >
+                  자동 가격조정 설정
+                </Button>
               </Stack>
 
               <Divider />

--- a/src/domain/pricing/auto-adjust-rule.test.ts
+++ b/src/domain/pricing/auto-adjust-rule.test.ts
@@ -1,0 +1,101 @@
+import {
+  autoAdjustRuleInputSchema,
+  buildAutoAdjustRuleFormValues,
+  toAutoAdjustRuleDisplayModel,
+  validateAutoAdjustRuleInput,
+  type AutoAdjustRule
+} from "@/domain/pricing/auto-adjust-rule";
+
+const listingId = "b9c0d2d8-20f8-4d2e-b4a8-84dba2be8e1b";
+
+describe("autoAdjustRuleInputSchema", () => {
+  it("accepts a valid listing-scoped rule and normalizes numeric strings", () => {
+    const parsed = autoAdjustRuleInputSchema.parse({
+      listingId,
+      periodDays: "14",
+      discountRatePercent: "8",
+      floorPriceKrw: "1200000"
+    });
+
+    expect(parsed).toEqual({
+      listingId,
+      periodDays: 14,
+      discountRatePercent: 8,
+      floorPriceKrw: 1_200_000
+    });
+  });
+
+  it("rejects invalid period, discount, and floor boundaries", () => {
+    expect(() =>
+      autoAdjustRuleInputSchema.parse({
+        listingId,
+        periodDays: "0",
+        discountRatePercent: "8",
+        floorPriceKrw: "1200000"
+      })
+    ).toThrow("주기는 1일 이상");
+
+    expect(() =>
+      autoAdjustRuleInputSchema.parse({
+        listingId,
+        periodDays: "14",
+        discountRatePercent: "101",
+        floorPriceKrw: "1200000"
+      })
+    ).toThrow("인하율은 50% 이하");
+
+    expect(() =>
+      autoAdjustRuleInputSchema.parse({
+        listingId,
+        periodDays: "14",
+        discountRatePercent: "8",
+        floorPriceKrw: "0"
+      })
+    ).toThrow("최저가 하한");
+  });
+
+  it("rejects unsafe floor combinations against the current listing price", () => {
+    const result = validateAutoAdjustRuleInput(
+      {
+        listingId,
+        periodDays: "14",
+        discountRatePercent: "8",
+        floorPriceKrw: "1850000"
+      },
+      {
+        currentPriceKrw: 1_850_000
+      }
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.ok ? null : result.fieldErrors.floorPriceKrw).toContain(
+      "현재 가격보다 낮아야"
+    );
+  });
+});
+
+describe("auto-adjust rule display helpers", () => {
+  const activeRule: AutoAdjustRule = {
+    listingId,
+    periodDays: 14,
+    discountRatePercent: 8,
+    floorPriceKrw: 1_200_000,
+    enabled: true,
+    updatedAt: "2026-04-22T00:00:00.000Z"
+  };
+
+  it("builds form values from the last valid active rule", () => {
+    expect(buildAutoAdjustRuleFormValues(activeRule)).toEqual({
+      periodDays: "14",
+      discountRatePercent: "8",
+      floorPriceKrw: "1200000"
+    });
+  });
+
+  it("builds a seller-readable active rule summary", () => {
+    expect(toAutoAdjustRuleDisplayModel(activeRule)).toMatchObject({
+      summary: "14일마다 8% 인하, 최저 1,200,000원"
+    });
+  });
+});
+

--- a/src/domain/pricing/auto-adjust-rule.test.ts
+++ b/src/domain/pricing/auto-adjust-rule.test.ts
@@ -73,7 +73,6 @@ describe("autoAdjustRuleInputSchema", () => {
     );
   });
 });
-
 describe("auto-adjust rule display helpers", () => {
   const activeRule: AutoAdjustRule = {
     listingId,
@@ -98,4 +97,3 @@ describe("auto-adjust rule display helpers", () => {
     });
   });
 });
-

--- a/src/domain/pricing/auto-adjust-rule.ts
+++ b/src/domain/pricing/auto-adjust-rule.ts
@@ -1,0 +1,230 @@
+import { z, type ZodError } from "zod";
+
+import { listingIdSchema, listingPricePolicy } from "@/domain/listing/listing";
+
+export const autoAdjustRulePolicy = {
+  minPeriodDays: 1,
+  maxPeriodDays: 365,
+  minDiscountRatePercent: 1,
+  maxDiscountRatePercent: 50
+} as const;
+
+export const autoAdjustRuleFieldLabels = {
+  periodDays: "주기(일)",
+  discountRatePercent: "인하율(%)",
+  floorPriceKrw: "최저가 하한 (원)"
+} as const;
+
+export type AutoAdjustRuleField = keyof typeof autoAdjustRuleFieldLabels;
+
+export type AutoAdjustRuleFieldErrors = Partial<
+  Record<AutoAdjustRuleField, string>
+>;
+
+export type AutoAdjustRuleFormValues = Record<AutoAdjustRuleField, string>;
+
+export const emptyAutoAdjustRuleFormValues: AutoAdjustRuleFormValues = {
+  periodDays: "",
+  discountRatePercent: "",
+  floorPriceKrw: ""
+};
+
+export const autoAdjustRuleInputSchema = z.object({
+  listingId: listingIdSchema,
+  periodDays: z.coerce
+    .number()
+    .int("주기는 정수 일수로 입력해 주세요.")
+    .min(
+      autoAdjustRulePolicy.minPeriodDays,
+      "주기는 1일 이상 입력해 주세요."
+    )
+    .max(
+      autoAdjustRulePolicy.maxPeriodDays,
+      `주기는 ${autoAdjustRulePolicy.maxPeriodDays}일 이하로 입력해 주세요.`
+    ),
+  discountRatePercent: z.coerce
+    .number()
+    .int("인하율은 정수 퍼센트로 입력해 주세요.")
+    .min(
+      autoAdjustRulePolicy.minDiscountRatePercent,
+      "인하율은 1% 이상 입력해 주세요."
+    )
+    .max(
+      autoAdjustRulePolicy.maxDiscountRatePercent,
+      `인하율은 ${autoAdjustRulePolicy.maxDiscountRatePercent}% 이하로 입력해 주세요.`
+    ),
+  floorPriceKrw: z.coerce
+    .number()
+    .int("최저가 하한은 정수 원화로 입력해 주세요.")
+    .min(
+      listingPricePolicy.minPriceKrw,
+      "최저가 하한은 1원 이상 입력해 주세요."
+    )
+    .max(
+      listingPricePolicy.maxPriceKrw,
+      `최저가 하한은 ${listingPricePolicy.maxPriceKrw.toLocaleString(
+        "ko-KR"
+      )}원 이하로 입력해 주세요.`
+    )
+    .refine(
+      (value) => value % listingPricePolicy.stepKrw === 0,
+      "최저가 하한은 1,000원 단위로 입력해 주세요."
+    )
+});
+
+export const autoAdjustRuleSchema = autoAdjustRuleInputSchema.extend({
+  enabled: z.boolean(),
+  updatedAt: z.iso.datetime()
+});
+
+export type AutoAdjustRuleInput = z.infer<typeof autoAdjustRuleInputSchema>;
+export type AutoAdjustRule = z.infer<typeof autoAdjustRuleSchema>;
+
+export type AutoAdjustRuleDisplayModel = AutoAdjustRuleFormValues & {
+  enabled: boolean;
+  updatedAt: string;
+  summary: string;
+};
+
+export type AutoAdjustRuleValidationResult =
+  | {
+      ok: true;
+      rule: AutoAdjustRuleInput;
+      fieldErrors: Record<string, never>;
+      recoveryGuide: null;
+    }
+  | {
+      ok: false;
+      fieldErrors: AutoAdjustRuleFieldErrors;
+      recoveryGuide: string;
+    };
+
+export class RetryableAutoAdjustRuleSaveError extends Error {
+  constructor(message = "Retryable auto-adjust rule persistence failure.", options?: ErrorOptions) {
+    super(message, options);
+    this.name = "RetryableAutoAdjustRuleSaveError";
+  }
+}
+
+const recoveryGuideByField: Record<AutoAdjustRuleField, string> = {
+  periodDays: "1일 이상 365일 이하의 정수로 다시 입력해 주세요.",
+  discountRatePercent: "1% 이상 50% 이하의 정수로 다시 입력해 주세요.",
+  floorPriceKrw:
+    "현재 가격보다 낮은 금액을 1,000원 단위 정수 원화로 다시 입력해 주세요."
+};
+
+const priceFormatter = new Intl.NumberFormat("ko-KR");
+
+function formatPriceKrw(priceKrw: number): string {
+  return `${priceFormatter.format(priceKrw)}원`;
+}
+
+function mapZodErrorToFieldErrors(error: ZodError): AutoAdjustRuleFieldErrors {
+  const fieldErrors: AutoAdjustRuleFieldErrors = {};
+
+  error.issues.forEach((issue) => {
+    const [field] = issue.path;
+
+    if (field === "periodDays") {
+      fieldErrors.periodDays = issue.message;
+      return;
+    }
+
+    if (field === "discountRatePercent") {
+      fieldErrors.discountRatePercent = issue.message;
+      return;
+    }
+
+    if (field === "floorPriceKrw") {
+      fieldErrors.floorPriceKrw = issue.message;
+    }
+  });
+
+  return fieldErrors;
+}
+
+function buildRecoveryGuide(fieldErrors: AutoAdjustRuleFieldErrors): string {
+  const guides = (Object.keys(fieldErrors) as AutoAdjustRuleField[]).map(
+    (field) => recoveryGuideByField[field]
+  );
+
+  if (guides.length === 0) {
+    return "입력값을 확인한 뒤 다시 저장해 주세요.";
+  }
+
+  return Array.from(new Set(guides)).join(" ");
+}
+
+export function validateAutoAdjustRuleInput(
+  rawInput: unknown,
+  options: {
+    currentPriceKrw?: number;
+  } = {}
+): AutoAdjustRuleValidationResult {
+  const parsedRule = autoAdjustRuleInputSchema.safeParse(rawInput);
+
+  if (!parsedRule.success) {
+    const fieldErrors = mapZodErrorToFieldErrors(parsedRule.error);
+
+    return {
+      ok: false,
+      fieldErrors,
+      recoveryGuide: buildRecoveryGuide(fieldErrors)
+    };
+  }
+
+  if (
+    typeof options.currentPriceKrw === "number" &&
+    parsedRule.data.floorPriceKrw >= options.currentPriceKrw
+  ) {
+    const fieldErrors: AutoAdjustRuleFieldErrors = {
+      floorPriceKrw: "최저가 하한은 현재 가격보다 낮아야 합니다."
+    };
+
+    return {
+      ok: false,
+      fieldErrors,
+      recoveryGuide: buildRecoveryGuide(fieldErrors)
+    };
+  }
+
+  return {
+    ok: true,
+    rule: parsedRule.data,
+    fieldErrors: {},
+    recoveryGuide: null
+  };
+}
+
+export function buildAutoAdjustRuleFormValues(
+  rule: AutoAdjustRule | null
+): AutoAdjustRuleFormValues {
+  if (!rule) {
+    return emptyAutoAdjustRuleFormValues;
+  }
+
+  return {
+    periodDays: String(rule.periodDays),
+    discountRatePercent: String(rule.discountRatePercent),
+    floorPriceKrw: String(rule.floorPriceKrw)
+  };
+}
+
+export function toAutoAdjustRuleDisplayModel(
+  rule: AutoAdjustRule | null
+): AutoAdjustRuleDisplayModel | null {
+  if (!rule) {
+    return null;
+  }
+
+  const values = buildAutoAdjustRuleFormValues(rule);
+
+  return {
+    ...values,
+    enabled: rule.enabled,
+    updatedAt: rule.updatedAt,
+    summary: `${rule.periodDays}일마다 ${rule.discountRatePercent}% 인하, 최저 ${formatPriceKrw(
+      rule.floorPriceKrw
+    )}`
+  };
+}

--- a/src/feature/listing/actions/save-auto-adjust-rule.action.test.ts
+++ b/src/feature/listing/actions/save-auto-adjust-rule.action.test.ts
@@ -1,0 +1,114 @@
+import { RetryableAutoAdjustRuleSaveError } from "@/domain/pricing/auto-adjust-rule";
+import {
+  createInitialSaveAutoAdjustRuleFormState,
+  handleSaveAutoAdjustRuleSubmission
+} from "@/feature/listing/actions/save-auto-adjust-rule.action";
+
+const listingId = "32b30d38-7fb0-4aa8-8ef4-ebfc558102da";
+
+function buildFormData(values: Record<string, string>): FormData {
+  const formData = new FormData();
+
+  Object.entries(values).forEach(([key, value]) => {
+    formData.set(key, value);
+  });
+
+  return formData;
+}
+
+const activeRule = {
+  listingId,
+  periodDays: 14,
+  discountRatePercent: 8,
+  floorPriceKrw: 1_200_000,
+  enabled: true,
+  updatedAt: "2026-04-22T00:00:00.000Z"
+};
+
+describe("handleSaveAutoAdjustRuleSubmission", () => {
+  it("stores a valid rule and returns the active rule summary", async () => {
+    const result = await handleSaveAutoAdjustRuleSubmission(
+      {
+        saveAutoAdjustRule: async (input) => ({
+          ...input,
+          enabled: true,
+          updatedAt: "2026-04-22T00:05:00.000Z"
+        })
+      },
+      listingId,
+      1_850_000,
+      createInitialSaveAutoAdjustRuleFormState(null),
+      buildFormData({
+        periodDays: "14",
+        discountRatePercent: "8",
+        floorPriceKrw: "1200000"
+      })
+    );
+
+    expect(result.submissionStatus).toBe("success");
+    expect(result.activeRule?.summary).toBe(
+      "14일마다 8% 인하, 최저 1,200,000원"
+    );
+    expect(result.values).toEqual({
+      periodDays: "14",
+      discountRatePercent: "8",
+      floorPriceKrw: "1200000"
+    });
+  });
+
+  it("keeps the last valid rule when invalid input is submitted", async () => {
+    const result = await handleSaveAutoAdjustRuleSubmission(
+      {
+        saveAutoAdjustRule: async () => {
+          throw new Error("should not be called");
+        }
+      },
+      listingId,
+      1_850_000,
+      createInitialSaveAutoAdjustRuleFormState(activeRule),
+      buildFormData({
+        periodDays: "0",
+        discountRatePercent: "101",
+        floorPriceKrw: "0"
+      })
+    );
+
+    expect(result.submissionStatus).toBe("error");
+    expect(result.formError).toContain("유효성 검증");
+    expect(result.values).toEqual({
+      periodDays: "14",
+      discountRatePercent: "8",
+      floorPriceKrw: "1200000"
+    });
+    expect(result.activeRule?.summary).toContain("14일마다 8% 인하");
+    expect(result.errorFieldLabels).toEqual([
+      "주기(일)",
+      "인하율(%)",
+      "최저가 하한 (원)"
+    ]);
+  });
+
+  it("keeps the last valid rule when persistence is retryable", async () => {
+    const result = await handleSaveAutoAdjustRuleSubmission(
+      {
+        saveAutoAdjustRule: async () => {
+          throw new RetryableAutoAdjustRuleSaveError("database offline");
+        }
+      },
+      listingId,
+      1_850_000,
+      createInitialSaveAutoAdjustRuleFormState(activeRule),
+      buildFormData({
+        periodDays: "21",
+        discountRatePercent: "5",
+        floorPriceKrw: "1100000"
+      })
+    );
+
+    expect(result.submissionStatus).toBe("error");
+    expect(result.formError).toContain("저장에 실패");
+    expect(result.values.floorPriceKrw).toBe("1200000");
+    expect(result.activeRule?.floorPriceKrw).toBe("1200000");
+  });
+});
+

--- a/src/feature/listing/actions/save-auto-adjust-rule.action.test.ts
+++ b/src/feature/listing/actions/save-auto-adjust-rule.action.test.ts
@@ -88,6 +88,35 @@ describe("handleSaveAutoAdjustRuleSubmission", () => {
     ]);
   });
 
+  it("keeps attempted invalid values when no active rule exists yet", async () => {
+    const result = await handleSaveAutoAdjustRuleSubmission(
+      {
+        saveAutoAdjustRule: async () => {
+          throw new Error("should not be called");
+        }
+      },
+      listingId,
+      1_850_000,
+      createInitialSaveAutoAdjustRuleFormState(null),
+      buildFormData({
+        periodDays: "0",
+        discountRatePercent: "101",
+        floorPriceKrw: "0"
+      })
+    );
+
+    expect(result.submissionStatus).toBe("error");
+    expect(result.values).toEqual({
+      periodDays: "0",
+      discountRatePercent: "101",
+      floorPriceKrw: "0"
+    });
+    expect(result.activeRule).toBeNull();
+    expect(result.recoveryGuide).toContain(
+      "1일 이상 365일 이하의 정수로 다시 입력해 주세요."
+    );
+  });
+
   it("keeps the last valid rule when persistence is retryable", async () => {
     const result = await handleSaveAutoAdjustRuleSubmission(
       {
@@ -111,4 +140,3 @@ describe("handleSaveAutoAdjustRuleSubmission", () => {
     expect(result.activeRule?.floorPriceKrw).toBe("1200000");
   });
 });
-

--- a/src/feature/listing/actions/save-auto-adjust-rule.action.ts
+++ b/src/feature/listing/actions/save-auto-adjust-rule.action.ts
@@ -1,0 +1,179 @@
+import {
+  autoAdjustRuleFieldLabels,
+  buildAutoAdjustRuleFormValues,
+  emptyAutoAdjustRuleFormValues,
+  RetryableAutoAdjustRuleSaveError,
+  toAutoAdjustRuleDisplayModel,
+  validateAutoAdjustRuleInput,
+  type AutoAdjustRule,
+  type AutoAdjustRuleDisplayModel,
+  type AutoAdjustRuleField,
+  type AutoAdjustRuleFieldErrors,
+  type AutoAdjustRuleFormValues,
+  type AutoAdjustRuleInput
+} from "@/domain/pricing/auto-adjust-rule";
+import { getAutoAdjustRuleRepository } from "@/infra/pricing/auto-adjust-rule.repository";
+
+export type SaveAutoAdjustRuleFormState = {
+  submissionStatus: "idle" | "success" | "error";
+  values: AutoAdjustRuleFormValues;
+  fieldErrors: AutoAdjustRuleFieldErrors;
+  errorFieldLabels: string[];
+  formError: string | null;
+  recoveryGuide: string | null;
+  activeRule: AutoAdjustRuleDisplayModel | null;
+};
+
+type SaveAutoAdjustRuleDependencies = {
+  saveAutoAdjustRule: (input: AutoAdjustRuleInput) => Promise<AutoAdjustRule | null>;
+};
+
+export function createInitialSaveAutoAdjustRuleFormState(
+  activeRule: AutoAdjustRule | null
+): SaveAutoAdjustRuleFormState {
+  const activeDisplayRule = toAutoAdjustRuleDisplayModel(activeRule);
+
+  return {
+    submissionStatus: "idle",
+    values: buildAutoAdjustRuleFormValues(activeRule),
+    fieldErrors: {},
+    errorFieldLabels: [],
+    formError: null,
+    recoveryGuide: null,
+    activeRule: activeDisplayRule
+  };
+}
+
+function readTextField(formData: FormData, key: AutoAdjustRuleField): string {
+  const rawValue = formData.get(key);
+
+  return typeof rawValue === "string" ? rawValue : "";
+}
+
+function extractFormValues(formData: FormData): AutoAdjustRuleFormValues {
+  return {
+    periodDays: readTextField(formData, "periodDays"),
+    discountRatePercent: readTextField(formData, "discountRatePercent"),
+    floorPriceKrw: readTextField(formData, "floorPriceKrw")
+  };
+}
+
+function buildValidationErrorFieldLabels(
+  fieldErrors: AutoAdjustRuleFieldErrors
+): string[] {
+  return (Object.keys(fieldErrors) as AutoAdjustRuleField[]).map(
+    (field) => autoAdjustRuleFieldLabels[field]
+  );
+}
+
+function buildPreservedValues(
+  previousState: SaveAutoAdjustRuleFormState,
+  attemptedValues: AutoAdjustRuleFormValues
+): AutoAdjustRuleFormValues {
+  if (!previousState.activeRule) {
+    return attemptedValues;
+  }
+
+  return {
+    periodDays: previousState.activeRule.periodDays,
+    discountRatePercent: previousState.activeRule.discountRatePercent,
+    floorPriceKrw: previousState.activeRule.floorPriceKrw
+  };
+}
+
+function toErrorState(
+  previousState: SaveAutoAdjustRuleFormState,
+  attemptedValues: AutoAdjustRuleFormValues,
+  input: {
+    fieldErrors?: AutoAdjustRuleFieldErrors;
+    formError: string;
+    recoveryGuide: string;
+  }
+): SaveAutoAdjustRuleFormState {
+  const fieldErrors = input.fieldErrors ?? {};
+
+  return {
+    submissionStatus: "error",
+    values: buildPreservedValues(previousState, attemptedValues),
+    fieldErrors,
+    errorFieldLabels: buildValidationErrorFieldLabels(fieldErrors),
+    formError: input.formError,
+    recoveryGuide: input.recoveryGuide,
+    activeRule: previousState.activeRule
+  };
+}
+
+export async function handleSaveAutoAdjustRuleSubmission(
+  dependencies: SaveAutoAdjustRuleDependencies,
+  rawListingId: string,
+  currentPriceKrw: number,
+  previousState: SaveAutoAdjustRuleFormState,
+  formData: FormData
+): Promise<SaveAutoAdjustRuleFormState> {
+  const values = extractFormValues(formData);
+  const validationResult = validateAutoAdjustRuleInput(
+    {
+      listingId: rawListingId,
+      ...values
+    },
+    {
+      currentPriceKrw
+    }
+  );
+
+  if (!validationResult.ok) {
+    return toErrorState(previousState, values, {
+      fieldErrors: validationResult.fieldErrors,
+      formError:
+        "유효성 검증에 실패했습니다. 마지막으로 저장된 유효 규칙은 그대로 유지됩니다.",
+      recoveryGuide: validationResult.recoveryGuide
+    });
+  }
+
+  try {
+    const storedRule = await dependencies.saveAutoAdjustRule(validationResult.rule);
+
+    if (!storedRule) {
+      return toErrorState(previousState, values, {
+        formError: "매물을 다시 불러온 뒤 가격조정 규칙을 저장해 주세요.",
+        recoveryGuide:
+          "다른 화면에서 매물이 삭제되었을 수 있습니다. 목록으로 돌아가 매물을 다시 확인해 주세요."
+      });
+    }
+
+    return {
+      submissionStatus: "success",
+      values: buildAutoAdjustRuleFormValues(storedRule),
+      fieldErrors: {},
+      errorFieldLabels: [],
+      formError: null,
+      recoveryGuide: null,
+      activeRule: toAutoAdjustRuleDisplayModel(storedRule)
+    };
+  } catch (error) {
+    if (error instanceof RetryableAutoAdjustRuleSaveError) {
+      return toErrorState(previousState, values, {
+        formError:
+          "가격조정 규칙 저장에 실패했습니다. 마지막으로 저장된 유효 규칙은 유지됩니다.",
+        recoveryGuide: "잠시 후 같은 값으로 다시 저장해 주세요."
+      });
+    }
+
+    throw error;
+  }
+}
+
+export async function saveActiveAutoAdjustRuleForListing(
+  input: AutoAdjustRuleInput
+): Promise<AutoAdjustRule | null> {
+  return getAutoAdjustRuleRepository().upsertActive(input);
+}
+
+export async function getActiveAutoAdjustRuleForListing(
+  listingId: string
+): Promise<AutoAdjustRule | null> {
+  return getAutoAdjustRuleRepository().findActiveByListingId(listingId);
+}
+
+export { emptyAutoAdjustRuleFormValues };
+

--- a/src/feature/listing/actions/save-auto-adjust-rule.action.ts
+++ b/src/feature/listing/actions/save-auto-adjust-rule.action.ts
@@ -176,4 +176,3 @@ export async function getActiveAutoAdjustRuleForListing(
 }
 
 export { emptyAutoAdjustRuleFormValues };
-

--- a/src/feature/listing/components/auto-adjust-rule-selector.client.tsx
+++ b/src/feature/listing/components/auto-adjust-rule-selector.client.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useActionState } from "react";
+import {
+  Alert,
+  AlertTitle,
+  Box,
+  Button,
+  Chip,
+  Paper,
+  Stack,
+  TextField,
+  Typography
+} from "@mui/material";
+
+import {
+  type SaveAutoAdjustRuleFormState
+} from "@/feature/listing/actions/save-auto-adjust-rule.action";
+
+type AutoAdjustRuleSelectorProps = {
+  action: (
+    previousState: SaveAutoAdjustRuleFormState,
+    formData: FormData
+  ) => Promise<SaveAutoAdjustRuleFormState>;
+  initialState: SaveAutoAdjustRuleFormState;
+};
+
+const numericSlotProps = {
+  htmlInput: {
+    inputMode: "numeric",
+    pattern: "[0-9]*"
+  }
+} as const;
+
+export function AutoAdjustRuleSelector({
+  action,
+  initialState
+}: AutoAdjustRuleSelectorProps) {
+  const [state, formAction, pending] = useActionState(action, initialState);
+  const formResetKey = JSON.stringify({
+    submissionStatus: state.submissionStatus,
+    values: state.values,
+    activeSummary: state.activeRule?.summary ?? ""
+  });
+
+  const statusMessage =
+    state.submissionStatus === "success"
+      ? `규칙이 저장되었습니다. 현재 활성 규칙: ${state.activeRule?.summary ?? "없음"}`
+      : `현재 활성 규칙: ${state.activeRule?.summary ?? "없음"}`;
+
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        border: "1px solid rgba(11, 110, 153, 0.12)",
+        p: { xs: 2, md: 4 }
+      }}
+    >
+      <Stack spacing={2.5}>
+        <Stack spacing={1}>
+          <Typography
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            data-testid="auto-adjust-rule-save-status"
+            color="text.secondary"
+          >
+            {statusMessage}
+          </Typography>
+
+          <Box
+            data-testid="auto-adjust-rule-active-summary"
+            sx={{
+              border: "1px solid rgba(11, 110, 153, 0.16)",
+              p: 2
+            }}
+          >
+            <Stack
+              direction={{ xs: "column", sm: "row" }}
+              spacing={1}
+              sx={{ alignItems: { sm: "center" }, justifyContent: "space-between" }}
+            >
+              <Stack spacing={0.5}>
+                <Typography variant="overline">활성 규칙</Typography>
+                <Typography sx={{ fontWeight: 700 }}>
+                  {state.activeRule?.summary ?? "아직 설정된 규칙이 없습니다."}
+                </Typography>
+              </Stack>
+              <Chip
+                label={state.activeRule?.enabled ? "활성" : "미설정"}
+                color={state.activeRule?.enabled ? "primary" : "default"}
+                sx={{ alignSelf: { xs: "flex-start", sm: "center" } }}
+              />
+            </Stack>
+          </Box>
+        </Stack>
+
+        {state.formError ? (
+          <Alert severity="error" aria-live="assertive" aria-atomic="true">
+            <AlertTitle>{state.formError}</AlertTitle>
+            {state.recoveryGuide ? (
+              <Typography variant="body2">{state.recoveryGuide}</Typography>
+            ) : null}
+            {state.errorFieldLabels.length > 0 ? (
+              <Stack
+                direction="row"
+                spacing={1}
+                useFlexGap
+                sx={{ flexWrap: "wrap", mt: 1 }}
+              >
+                {state.errorFieldLabels.map((label) => (
+                  <Chip
+                    key={label}
+                    label={label}
+                    color="error"
+                    variant="outlined"
+                    size="small"
+                  />
+                ))}
+              </Stack>
+            ) : null}
+          </Alert>
+        ) : null}
+
+        <Box
+          key={formResetKey}
+          component="form"
+          action={formAction}
+          data-testid="auto-adjust-rule-form"
+          noValidate
+        >
+          <Stack spacing={2}>
+            <TextField
+              name="periodDays"
+              label="주기(일)"
+              defaultValue={state.values.periodDays}
+              error={Boolean(state.fieldErrors.periodDays)}
+              helperText={
+                state.fieldErrors.periodDays ??
+                "자동 가격조정을 실행할 일 단위 주기를 입력해 주세요."
+              }
+              disabled={pending}
+              fullWidth
+              autoComplete="off"
+              slotProps={numericSlotProps}
+            />
+
+            <TextField
+              name="discountRatePercent"
+              label="인하율(%)"
+              defaultValue={state.values.discountRatePercent}
+              error={Boolean(state.fieldErrors.discountRatePercent)}
+              helperText={
+                state.fieldErrors.discountRatePercent ??
+                "한 번 실행될 때 인하할 정수 퍼센트를 입력해 주세요."
+              }
+              disabled={pending}
+              fullWidth
+              autoComplete="off"
+              slotProps={numericSlotProps}
+            />
+
+            <TextField
+              name="floorPriceKrw"
+              label="최저가 하한 (원)"
+              defaultValue={state.values.floorPriceKrw}
+              error={Boolean(state.fieldErrors.floorPriceKrw)}
+              helperText={
+                state.fieldErrors.floorPriceKrw ??
+                "현재 가격보다 낮은 원화 금액을 1,000원 단위로 입력해 주세요."
+              }
+              disabled={pending}
+              fullWidth
+              autoComplete="off"
+              slotProps={numericSlotProps}
+            />
+
+            <Button
+              type="submit"
+              variant="contained"
+              size="large"
+              disabled={pending}
+              aria-busy={pending}
+              sx={{ alignSelf: "flex-start", minHeight: 48, minWidth: 148 }}
+            >
+              {pending ? "저장 중..." : "규칙 저장"}
+            </Button>
+          </Stack>
+        </Box>
+      </Stack>
+    </Paper>
+  );
+}

--- a/src/infra/pricing/auto-adjust-rule.repository.test.ts
+++ b/src/infra/pricing/auto-adjust-rule.repository.test.ts
@@ -63,6 +63,47 @@ describe("autoAdjustRule.repository", () => {
     });
   });
 
+  it("reads the active rule used to prefill the rule setup form", async () => {
+    const repository = createAutoAdjustRuleRepository(mockPrismaClient);
+
+    mockFindUnique.mockResolvedValueOnce({
+      listingId: "916df0fd-cc73-48cb-84e9-837c9748c968",
+      periodDays: 21,
+      discountRatePercent: 5,
+      floorPriceKrw: 1_100_000,
+      enabled: true,
+      updatedAt: new Date("2026-04-22T00:10:00.000Z")
+    });
+
+    await expect(
+      repository.findActiveByListingId("916df0fd-cc73-48cb-84e9-837c9748c968")
+    ).resolves.toMatchObject({
+      listingId: "916df0fd-cc73-48cb-84e9-837c9748c968",
+      periodDays: 21,
+      discountRatePercent: 5,
+      floorPriceKrw: 1_100_000,
+      enabled: true,
+      updatedAt: "2026-04-22T00:10:00.000Z"
+    });
+  });
+
+  it("does not expose disabled rules as active prefill state", async () => {
+    const repository = createAutoAdjustRuleRepository(mockPrismaClient);
+
+    mockFindUnique.mockResolvedValueOnce({
+      listingId: "916df0fd-cc73-48cb-84e9-837c9748c968",
+      periodDays: 21,
+      discountRatePercent: 5,
+      floorPriceKrw: 1_100_000,
+      enabled: false,
+      updatedAt: new Date("2026-04-22T00:10:00.000Z")
+    });
+
+    await expect(
+      repository.findActiveByListingId("916df0fd-cc73-48cb-84e9-837c9748c968")
+    ).resolves.toBeNull();
+  });
+
   it("returns null when the listing foreign key no longer exists", async () => {
     const repository = createAutoAdjustRuleRepository(mockPrismaClient);
 
@@ -102,4 +143,3 @@ describe("autoAdjustRule.repository", () => {
     ).rejects.toBeInstanceOf(RetryableAutoAdjustRuleSaveError);
   });
 });
-

--- a/src/infra/pricing/auto-adjust-rule.repository.test.ts
+++ b/src/infra/pricing/auto-adjust-rule.repository.test.ts
@@ -1,0 +1,105 @@
+import { Prisma } from "@prisma/client";
+
+import { RetryableAutoAdjustRuleSaveError } from "@/domain/pricing/auto-adjust-rule";
+import { createAutoAdjustRuleRepository } from "@/infra/pricing/auto-adjust-rule.repository";
+
+const mockFindUnique = jest.fn();
+const mockUpsert = jest.fn();
+
+const mockPrismaClient = {
+  autoAdjustRule: {
+    findUnique: mockFindUnique,
+    upsert: mockUpsert,
+    deleteMany: jest.fn()
+  }
+};
+
+describe("autoAdjustRule.repository", () => {
+  beforeEach(() => {
+    mockFindUnique.mockReset();
+    mockUpsert.mockReset();
+  });
+
+  it("upserts one active rule per listing and maps dates to domain strings", async () => {
+    const repository = createAutoAdjustRuleRepository(mockPrismaClient);
+
+    mockUpsert.mockResolvedValueOnce({
+      listingId: "916df0fd-cc73-48cb-84e9-837c9748c968",
+      periodDays: 14,
+      discountRatePercent: 8,
+      floorPriceKrw: 1_200_000,
+      enabled: true,
+      updatedAt: new Date("2026-04-22T00:00:00.000Z")
+    });
+
+    const rule = await repository.upsertActive({
+      listingId: "916df0fd-cc73-48cb-84e9-837c9748c968",
+      periodDays: 14,
+      discountRatePercent: 8,
+      floorPriceKrw: 1_200_000
+    });
+
+    expect(mockUpsert).toHaveBeenCalledWith({
+      where: {
+        listingId: "916df0fd-cc73-48cb-84e9-837c9748c968"
+      },
+      update: {
+        periodDays: 14,
+        discountRatePercent: 8,
+        floorPriceKrw: 1_200_000,
+        enabled: true
+      },
+      create: {
+        listingId: "916df0fd-cc73-48cb-84e9-837c9748c968",
+        periodDays: 14,
+        discountRatePercent: 8,
+        floorPriceKrw: 1_200_000,
+        enabled: true
+      }
+    });
+    expect(rule).toMatchObject({
+      listingId: "916df0fd-cc73-48cb-84e9-837c9748c968",
+      updatedAt: "2026-04-22T00:00:00.000Z"
+    });
+  });
+
+  it("returns null when the listing foreign key no longer exists", async () => {
+    const repository = createAutoAdjustRuleRepository(mockPrismaClient);
+
+    mockUpsert.mockRejectedValueOnce(
+      Object.assign(Object.create(Prisma.PrismaClientKnownRequestError.prototype), {
+        code: "P2003",
+        message: "Foreign key constraint failed"
+      })
+    );
+
+    await expect(
+      repository.upsertActive({
+        listingId: "916df0fd-cc73-48cb-84e9-837c9748c968",
+        periodDays: 14,
+        discountRatePercent: 8,
+        floorPriceKrw: 1_200_000
+      })
+    ).resolves.toBeNull();
+  });
+
+  it("wraps retryable Prisma write failures for recoverable form UX", async () => {
+    const repository = createAutoAdjustRuleRepository(mockPrismaClient);
+
+    mockUpsert.mockRejectedValueOnce(
+      Object.assign(Object.create(Prisma.PrismaClientUnknownRequestError.prototype), {
+        message: "database offline"
+      })
+    );
+
+    await expect(
+      repository.upsertActive({
+        listingId: "916df0fd-cc73-48cb-84e9-837c9748c968",
+        periodDays: 14,
+        discountRatePercent: 8,
+        floorPriceKrw: 1_200_000
+      })
+    ).rejects.toBeInstanceOf(RetryableAutoAdjustRuleSaveError);
+  });
+});
+

--- a/src/infra/pricing/auto-adjust-rule.repository.ts
+++ b/src/infra/pricing/auto-adjust-rule.repository.ts
@@ -1,0 +1,141 @@
+import { Prisma } from "@prisma/client";
+
+import {
+  autoAdjustRuleInputSchema,
+  autoAdjustRuleSchema,
+  RetryableAutoAdjustRuleSaveError,
+  type AutoAdjustRule,
+  type AutoAdjustRuleInput
+} from "@/domain/pricing/auto-adjust-rule";
+import { getPrismaClient } from "@/infra/prisma/prisma.client";
+
+type AutoAdjustRuleRecord = {
+  listingId: string;
+  periodDays: number;
+  discountRatePercent: number;
+  floorPriceKrw: number;
+  enabled: boolean;
+  updatedAt: Date;
+};
+
+type AutoAdjustRulePersistenceClient = {
+  autoAdjustRule: {
+    findUnique: (args: {
+      where: {
+        listingId: string;
+      };
+    }) => Promise<AutoAdjustRuleRecord | null>;
+    upsert: (args: {
+      where: {
+        listingId: string;
+      };
+      update: {
+        periodDays: number;
+        discountRatePercent: number;
+        floorPriceKrw: number;
+        enabled: boolean;
+      };
+      create: {
+        listingId: string;
+        periodDays: number;
+        discountRatePercent: number;
+        floorPriceKrw: number;
+        enabled: boolean;
+      };
+    }) => Promise<AutoAdjustRuleRecord>;
+    deleteMany: () => Promise<unknown>;
+  };
+};
+
+export type AutoAdjustRuleRepository = {
+  findActiveByListingId: (listingId: string) => Promise<AutoAdjustRule | null>;
+  upsertActive: (input: AutoAdjustRuleInput) => Promise<AutoAdjustRule | null>;
+};
+
+function toDomainAutoAdjustRule(record: AutoAdjustRuleRecord): AutoAdjustRule {
+  return autoAdjustRuleSchema.parse({
+    ...record,
+    updatedAt: record.updatedAt.toISOString()
+  });
+}
+
+function isRetryableRuleWriteError(error: unknown): boolean {
+  return (
+    error instanceof Prisma.PrismaClientInitializationError ||
+    error instanceof Prisma.PrismaClientUnknownRequestError
+  );
+}
+
+export function createAutoAdjustRuleRepository(
+  prismaClient: AutoAdjustRulePersistenceClient
+): AutoAdjustRuleRepository {
+  return {
+    async findActiveByListingId(listingId) {
+      const parsedListingId = autoAdjustRuleInputSchema.shape.listingId.parse(
+        listingId
+      );
+      const storedRule = await prismaClient.autoAdjustRule.findUnique({
+        where: {
+          listingId: parsedListingId
+        }
+      });
+
+      if (!storedRule || !storedRule.enabled) {
+        return null;
+      }
+
+      return toDomainAutoAdjustRule(storedRule);
+    },
+    async upsertActive(input) {
+      const parsedInput = autoAdjustRuleInputSchema.parse(input);
+      let storedRule: AutoAdjustRuleRecord;
+
+      try {
+        storedRule = await prismaClient.autoAdjustRule.upsert({
+          where: {
+            listingId: parsedInput.listingId
+          },
+          update: {
+            periodDays: parsedInput.periodDays,
+            discountRatePercent: parsedInput.discountRatePercent,
+            floorPriceKrw: parsedInput.floorPriceKrw,
+            enabled: true
+          },
+          create: {
+            listingId: parsedInput.listingId,
+            periodDays: parsedInput.periodDays,
+            discountRatePercent: parsedInput.discountRatePercent,
+            floorPriceKrw: parsedInput.floorPriceKrw,
+            enabled: true
+          }
+        });
+      } catch (error: unknown) {
+        if (
+          error instanceof Prisma.PrismaClientKnownRequestError &&
+          error.code === "P2003"
+        ) {
+          return null;
+        }
+
+        if (isRetryableRuleWriteError(error)) {
+          throw new RetryableAutoAdjustRuleSaveError(undefined, {
+            cause: error
+          });
+        }
+
+        throw error;
+      }
+
+      return toDomainAutoAdjustRule(storedRule);
+    }
+  };
+}
+
+export function getAutoAdjustRuleRepository(): AutoAdjustRuleRepository {
+  return createAutoAdjustRuleRepository(getPrismaClient());
+}
+
+export async function resetAutoAdjustRuleRepository(): Promise<void> {
+  await getPrismaClient().autoAdjustRule.deleteMany();
+}
+

--- a/src/infra/pricing/auto-adjust-rule.repository.ts
+++ b/src/infra/pricing/auto-adjust-rule.repository.ts
@@ -138,4 +138,3 @@ export function getAutoAdjustRuleRepository(): AutoAdjustRuleRepository {
 export async function resetAutoAdjustRuleRepository(): Promise<void> {
   await getPrismaClient().autoAdjustRule.deleteMany();
 }
-

--- a/tests/e2e/auto-adjust-rule-flow.spec.ts
+++ b/tests/e2e/auto-adjust-rule-flow.spec.ts
@@ -1,0 +1,127 @@
+import { expect, test } from "../support/fixtures/index.js";
+
+const hasDatabaseUrl = Boolean(process.env.DATABASE_URL);
+
+async function confirmManualPrice(
+  page: import("@playwright/test").Page,
+  priceKrw: string
+) {
+  await page.getByLabel("수동 가격 (원)").fill(priceKrw);
+  await page.getByRole("button", { name: "수동 가격 확정" }).click();
+}
+
+async function createListingForRule(
+  page: import("@playwright/test").Page,
+  title: string
+): Promise<string> {
+  await page.goto("/listings/new");
+
+  await page.getByLabel("제목").fill(title);
+  await page.getByLabel("카테고리").fill("노트북");
+  await page.getByLabel("핵심 스펙").fill("M4 Pro\n24GB RAM");
+  await confirmManualPrice(page, "1850000");
+  await page.getByRole("button", { name: "등록하고 상세 보기" }).click();
+  await expect(page).toHaveURL(/\/listings\/[0-9a-f-]+$/u);
+
+  const listingId = new URL(page.url()).pathname.split("/").at(-1);
+
+  if (!listingId) {
+    throw new Error("Expected listing detail URL to include a listing id.");
+  }
+
+  return listingId;
+}
+
+async function fillRuleForm(
+  page: import("@playwright/test").Page,
+  values: {
+    periodDays: string;
+    discountRatePercent: string;
+    floorPriceKrw: string;
+  }
+) {
+  await page.getByLabel("주기(일)", { exact: true }).fill(values.periodDays);
+  await page
+    .getByLabel("인하율(%)", { exact: true })
+    .fill(values.discountRatePercent);
+  await page
+    .getByLabel("최저가 하한 (원)", { exact: true })
+    .fill(values.floorPriceKrw);
+}
+
+test.describe("Auto-adjust rule flow", () => {
+  test.skip(
+    !hasDatabaseUrl,
+    "DATABASE_URL is required for DB-backed auto-adjust rule E2E tests."
+  );
+
+  test("saves, preserves, and reloads an active auto-adjust rule", async ({
+    page
+  }) => {
+    const listingId = await createListingForRule(
+      page,
+      "맥북 프로 14 auto-adjust-rule-flow"
+    );
+    const rulePagePath = `/listings/${listingId}/auto-adjust-rule`;
+
+    await page.getByRole("link", { name: "자동 가격조정 설정" }).click();
+    await expect(page).toHaveURL(rulePagePath);
+
+    await fillRuleForm(page, {
+      periodDays: "14",
+      discountRatePercent: "8",
+      floorPriceKrw: "1200000"
+    });
+    await page.getByRole("button", { name: "규칙 저장" }).click();
+
+    await expect(page.getByRole("status")).toContainText("규칙이 저장되었습니다");
+    await expect(page.getByTestId("auto-adjust-rule-active-summary")).toContainText(
+      "14일"
+    );
+    await expect(page.getByTestId("auto-adjust-rule-active-summary")).toContainText(
+      "8%"
+    );
+    await expect(page.getByTestId("auto-adjust-rule-active-summary")).toContainText(
+      "1,200,000원"
+    );
+
+    await fillRuleForm(page, {
+      periodDays: "0",
+      discountRatePercent: "101",
+      floorPriceKrw: "0"
+    });
+    await page.getByRole("button", { name: "규칙 저장" }).click();
+
+    await expect(
+      page.getByRole("alert").filter({ hasText: "유효성 검증" })
+    ).toContainText("유효성 검증");
+    await expect(page.getByLabel("주기(일)", { exact: true })).toHaveValue("14");
+    await expect(page.getByLabel("인하율(%)", { exact: true })).toHaveValue("8");
+    await expect(page.getByLabel("최저가 하한 (원)", { exact: true })).toHaveValue(
+      "1200000"
+    );
+    await expect(page.getByTestId("auto-adjust-rule-active-summary")).toContainText(
+      "14일"
+    );
+
+    await page.goto(`/listings/${listingId}`);
+    await expect(page.getByTestId("listing-detail-auto-adjust-rule")).toContainText(
+      "14일마다 8% 인하"
+    );
+    await page.goto(rulePagePath);
+
+    await expect(page.getByLabel("주기(일)", { exact: true })).toHaveValue("14");
+    await expect(page.getByLabel("인하율(%)", { exact: true })).toHaveValue("8");
+    await expect(page.getByLabel("최저가 하한 (원)", { exact: true })).toHaveValue(
+      "1200000"
+    );
+    await expect(page.getByRole("status")).toContainText("현재 활성 규칙");
+
+    await page.keyboard.press("Tab");
+    await expect(page.getByLabel("주기(일)", { exact: true })).toBeFocused();
+    await page.keyboard.press("Tab");
+    await expect(page.getByLabel("인하율(%)", { exact: true })).toBeFocused();
+    await page.keyboard.press("Tab");
+    await expect(page.getByLabel("최저가 하한 (원)", { exact: true })).toBeFocused();
+  });
+});

--- a/tests/e2e/auto-adjust-rule-flow.spec.ts
+++ b/tests/e2e/auto-adjust-rule-flow.spec.ts
@@ -92,9 +92,17 @@ test.describe("Auto-adjust rule flow", () => {
     });
     await page.getByRole("button", { name: "규칙 저장" }).click();
 
-    await expect(
-      page.getByRole("alert").filter({ hasText: "유효성 검증" })
-    ).toContainText("유효성 검증");
+    const validationAlert = page
+      .getByRole("alert")
+      .filter({ hasText: "유효성 검증" });
+
+    await expect(validationAlert).toContainText("유효성 검증");
+    await expect(validationAlert).toContainText(
+      "1일 이상 365일 이하의 정수로 다시 입력해 주세요."
+    );
+    await expect(page.getByText("주기는 1일 이상 입력해 주세요.")).toBeVisible();
+    await expect(page.getByText("인하율은 50% 이하로 입력해 주세요.")).toBeVisible();
+    await expect(page.getByText("최저가 하한은 1원 이상 입력해 주세요.")).toBeVisible();
     await expect(page.getByLabel("주기(일)", { exact: true })).toHaveValue("14");
     await expect(page.getByLabel("인하율(%)", { exact: true })).toHaveValue("8");
     await expect(page.getByLabel("최저가 하한 (원)", { exact: true })).toHaveValue(


### PR DESCRIPTION
Fixes #15

Summary:
- Story 3.1 auto-adjust rule setup branch is ready for review and merge.
- Exposes the listing-scoped auto-adjust rule flow and associated listing summary surface.

Test results:
- `pnpm run lint` ✅
- `pnpm run typecheck` ✅
- `pnpm run unit` ✅
- `pnpm run contract` ✅
- `pnpm run perf-budget` ✅
- `PLAYWRIGHT_WEB_SERVER_COMMAND='pnpm dev' pnpm exec playwright test tests/e2e/auto-adjust-rule-flow.spec.ts --project=chromium` ✅

GitHub Actions status:
- No workflow runs or commit statuses were present on the pushed commit, so local fallback checks were used.